### PR TITLE
Visual Studio support

### DIFF
--- a/src/HotAvalonia/AvaloniaHotReloadContext.cs
+++ b/src/HotAvalonia/AvaloniaHotReloadContext.cs
@@ -10,11 +10,6 @@ namespace HotAvalonia;
 public sealed class AvaloniaHotReloadContext : IDisposable
 {
     /// <summary>
-    /// File extensions to watch
-    /// </summary>
-    private static readonly IEnumerable<string> ExtensionsToWatch = [".axaml"];
-
-    /// <summary>
     /// The Avalonia control managers, mapped by their respective file paths.
     /// </summary>
     private readonly Dictionary<string, AvaloniaControlManager> _controls;
@@ -44,7 +39,7 @@ public sealed class AvaloniaHotReloadContext : IDisposable
             .Select(x => ResolveControlManager(x, rootPath))
             .ToDictionary(static x => x.FileName, FileHelper.FileNameComparer);
 
-        _watcher = new(rootPath, _controls.Keys, ExtensionsToWatch);
+        _watcher = new(rootPath, _controls.Keys);
         _watcher.Changed += OnChanged;
         _watcher.Moved += OnMoved;
         _watcher.Error += OnError;

--- a/src/HotAvalonia/AvaloniaHotReloadContext.cs
+++ b/src/HotAvalonia/AvaloniaHotReloadContext.cs
@@ -10,6 +10,11 @@ namespace HotAvalonia;
 public sealed class AvaloniaHotReloadContext : IDisposable
 {
     /// <summary>
+    /// File extensions to watch
+    /// </summary>
+    private static readonly IEnumerable<string> ExtensionsToWatch = [".axaml"];
+
+    /// <summary>
     /// The Avalonia control managers, mapped by their respective file paths.
     /// </summary>
     private readonly Dictionary<string, AvaloniaControlManager> _controls;
@@ -39,7 +44,7 @@ public sealed class AvaloniaHotReloadContext : IDisposable
             .Select(x => ResolveControlManager(x, rootPath))
             .ToDictionary(static x => x.FileName, FileHelper.FileNameComparer);
 
-        _watcher = new(rootPath, _controls.Keys);
+        _watcher = new(rootPath, _controls.Keys, ExtensionsToWatch);
         _watcher.Changed += OnChanged;
         _watcher.Moved += OnMoved;
         _watcher.Error += OnError;

--- a/src/HotAvalonia/Collections/MemoryCache.cs
+++ b/src/HotAvalonia/Collections/MemoryCache.cs
@@ -1,0 +1,123 @@
+using System.Collections;
+using HotAvalonia.Helpers;
+
+namespace HotAvalonia.Collections;
+
+/// <summary>
+/// Represents a memory cache that stores items of type <typeparamref name="T"/>.
+/// </summary>
+/// <typeparam name="T">The type of items to be stored in the cache.</typeparam>
+internal sealed class MemoryCache<T> : ICollection<T>, IReadOnlyCollection<T>
+{
+    /// <summary>
+    /// The list of entries stored in the memory cache.
+    /// </summary>
+    private readonly List<Entry> _entries;
+
+    /// <summary>
+    /// The lifespan of items in the cache.
+    /// </summary>
+    private readonly double _lifespan;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MemoryCache{T}"/> class with the specified lifespan.
+    /// </summary>
+    /// <param name="lifespan">The lifespan of items in the cache.</param>
+    public MemoryCache(TimeSpan lifespan)
+    {
+        _entries = new();
+        _lifespan = lifespan.TotalMilliseconds;
+    }
+
+    /// <summary>
+    /// Gets the lifespan of items in the cache.
+    /// </summary>
+    public TimeSpan Lifespan => TimeSpan.FromMilliseconds(_lifespan);
+
+    /// <inheritdoc/>
+    public int Count
+    {
+        get
+        {
+            RemoveStale();
+            return _entries.Count;
+        }
+    }
+
+    /// <inheritdoc/>
+    bool ICollection<T>.IsReadOnly => false;
+
+    /// <inheritdoc/>
+    public void Add(T item) => _entries.Add(new(item));
+
+    /// <inheritdoc/>
+    public bool Remove(T item) => _entries.RemoveAll(x => EqualityComparer<T>.Default.Equals(item, x.Value)) != 0;
+
+    /// <summary>
+    /// Removes stale entries from the cache based on their timestamp.
+    /// </summary>
+    private void RemoveStale()
+    {
+        long currentTimestamp = StopwatchHelper.GetTimestamp();
+        _entries.RemoveAll(x => StopwatchHelper.GetElapsedTime(x.Timestamp, currentTimestamp).TotalMilliseconds > _lifespan);
+    }
+
+    /// <inheritdoc/>
+    public void Clear() => _entries.Clear();
+
+    /// <inheritdoc/>
+    public bool Contains(T item) => _entries.Any(x => EqualityComparer<T>.Default.Equals(item, x.Value));
+
+    /// <inheritdoc/>
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        RemoveStale();
+        _entries.ConvertAll(static x => x.Value).CopyTo(array, arrayIndex);
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<T> GetEnumerator()
+    {
+        RemoveStale();
+        return _entries.Select(static x => x.Value).GetEnumerator();
+    }
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <summary>
+    /// Represents an entry in the cache containing the value and its timestamp.
+    /// </summary>
+    private sealed class Entry
+    {
+        /// <summary>
+        /// Gets the value stored in the cache entry.
+        /// </summary>
+        public T Value { get; }
+
+        /// <summary>
+        /// Gets the timestamp when the cache entry was added.
+        /// </summary>
+        public long Timestamp { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Entry"/> class with the specified value.
+        /// </summary>
+        /// <param name="value">The value to be stored in the cache entry.</param>
+        public Entry(T value)
+            : this(value, StopwatchHelper.GetTimestamp())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Entry"/> class with the specified value and timestamp.
+        /// </summary>
+        /// <param name="value">The value to be stored in the cache entry.</param>
+        /// <param name="timestamp">The timestamp when the cache entry was added.</param>
+        public Entry(T value, long timestamp)
+        {
+            Value = value;
+            Timestamp = timestamp;
+        }
+    }
+}

--- a/src/HotAvalonia/IO/FileWatcher.cs
+++ b/src/HotAvalonia/IO/FileWatcher.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+using HotAvalonia.Collections;
 using HotAvalonia.Helpers;
 
 namespace HotAvalonia.IO;
@@ -9,32 +9,14 @@ namespace HotAvalonia.IO;
 internal sealed class FileWatcher : IDisposable
 {
     /// <summary>
-    /// The minimum time difference required to consider a write operation as unique.
-    /// </summary>
-    /// <remarks>
-    /// https://en.wikipedia.org/wiki/Mental_chronometry#Measurement_and_mathematical_descriptions
-    /// </remarks>
-    private const double MinWriteTimeDifference = 150;
-
-    /// <summary>
-    /// The time duration for which create and delete events are buffered before being processed.
-    /// </summary>
-    private const double EventBufferLifetime = 100;
-
-    /// <summary>
     /// The set of tracked file paths.
     /// </summary>
     private readonly HashSet<string> _files;
 
     /// <summary>
-    /// The last write times for the tracked files.
+    /// The cache of filesystem events.
     /// </summary>
-    private readonly Dictionary<string, DateTime> _lastWriteTimes;
-
-    /// <summary>
-    /// The list of buffered create and delete events awaiting processing.
-    /// </summary>
-    private readonly List<(FileSystemEventArgs Event, long Timestamp)> _eventBuffer;
+    private readonly MemoryCache<FileSystemEventArgs> _eventCache;
 
     /// <summary>
     /// The object used for locking in thread-safe operations.
@@ -47,25 +29,22 @@ internal sealed class FileWatcher : IDisposable
     private FileSystemWatcher? _systemWatcher;
 
     /// <summary>
-    /// List of extensions to watch (including dot)
-    /// </summary>
-    private IEnumerable<string>? _extensionsToWatch;
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="FileWatcher"/> class.
     /// </summary>
     /// <param name="rootPath">The root directory to be watched.</param>
-    public FileWatcher(string rootPath, IEnumerable<string>? extensionsToWatch = null)
+    public FileWatcher(string rootPath)
     {
+        // The minimum time difference required to consider a write operation as unique.
+        // See: https://en.wikipedia.org/wiki/Mental_chronometry#Measurement_and_mathematical_descriptions
+        const double MinWriteTimeDifference = 150;
+
         _ = rootPath ?? throw new ArgumentNullException(nameof(rootPath));
         _ = Directory.Exists(rootPath) ? rootPath : throw new DirectoryNotFoundException(rootPath);
-        _extensionsToWatch = extensionsToWatch;
 
         DirectoryName = rootPath;
         _systemWatcher = CreateFileSystemWatcher(rootPath);
         _files = new(FileHelper.FileNameComparer);
-        _lastWriteTimes = new(FileHelper.FileNameComparer);
-        _eventBuffer = new();
+        _eventCache = new(TimeSpan.FromMilliseconds(MinWriteTimeDifference));
         _lock = new();
     }
 
@@ -74,8 +53,8 @@ internal sealed class FileWatcher : IDisposable
     /// </summary>
     /// <param name="rootPath">The root directory to be watched.</param>
     /// <param name="fileNames">The initial list of file names to be tracked.</param>
-    public FileWatcher(string rootPath, IEnumerable<string> fileNames, IEnumerable<string> extensionsToWatch)
-        : this(rootPath, extensionsToWatch)
+    public FileWatcher(string rootPath, IEnumerable<string> fileNames)
+        : this(rootPath)
     {
         _ = fileNames ?? throw new ArgumentNullException(nameof(fileNames));
 
@@ -121,19 +100,6 @@ internal sealed class FileWatcher : IDisposable
     }
 
     /// <summary>
-    /// The sequence of buffered create and delete events awaiting processing.
-    /// </summary>
-    private IEnumerable<FileSystemEventArgs> BufferedEvents
-    {
-        get
-        {
-            CleanupEventBuffer();
-
-            return _eventBuffer.Select(static x => x.Event);
-        }
-    }
-
-    /// <summary>
     /// Starts watching a specified file.
     /// </summary>
     /// <param name="fileName">The name of the file to be watched.</param>
@@ -168,67 +134,27 @@ internal sealed class FileWatcher : IDisposable
     /// <param name="sender">The source of the event.</param>
     /// <param name="args">The event arguments containing information about the file change.</param>
     private void OnCreatedOrDeleted(object sender, FileSystemEventArgs args)
-    {
-        var fullPath = args.FullPath;
-        if (!IsFileIncluded(fullPath))
-        {
-            return;
-        }
-        if (args.ChangeType == WatcherChangeTypes.Created)
-        {
-            LoggingHelper.Logger?.Log(this, "File created: {0}", GetRelativePath(fullPath));
-        }
-        if (args.ChangeType == WatcherChangeTypes.Deleted)
-        {
-            LoggingHelper.Logger?.Log(this, "File deleted: {0}", GetRelativePath(fullPath));
-        }
-
-        StringComparer fileNameComparer = FileHelper.FileNameComparer;
-        WatcherChangeTypes oppositeChangeType = args.ChangeType is WatcherChangeTypes.Created ? WatcherChangeTypes.Deleted : WatcherChangeTypes.Created;
-        string fileName = Path.GetFileName(fullPath);
-        string? newFullPath = null;
-        string? oldFullPath = null;
-
-        lock (_lock)
-        {
-            FileSystemEventArgs? bufferedArgs = BufferedEvents.FirstOrDefault(x => x.ChangeType == oppositeChangeType && fileNameComparer.Equals(Path.GetFileName(x.FullPath), fileName));
-            if (bufferedArgs is null)
-            {
-                BufferEvent(args);
-                return;
-            }
-
-            (newFullPath, oldFullPath) = args.ChangeType is WatcherChangeTypes.Created
-                ? (args.FullPath, bufferedArgs.FullPath)
-                : (bufferedArgs.FullPath, args.FullPath);
-        }
-
-        OnMoved(newFullPath, oldFullPath);
-    }
+        => OnFileSystemEvent(args, args.FullPath);
 
     /// <summary>
-    /// Processes the event of a file change..
+    /// Handles the event of a file change.
     /// </summary>
     /// <param name="sender">The source of the event.</param>
     /// <param name="args">The event arguments containing information about the file change.</param>
     private void OnChanged(object sender, FileSystemEventArgs args)
-    {
-        var fullPath = args.FullPath;
-        if(!IsFileIncluded(fullPath))
-        {
-            return;
-        }
-        LoggingHelper.Logger?.Log(this, "File changed: {0}, change type: {1}", GetRelativePath(fullPath), args.ChangeType);
+        => OnFileSystemEvent(args, args.FullPath, () => Changed?.Invoke(this, args));
 
-        string path = Path.GetFullPath(fullPath);
-        lock (_lock)
+    /// <summary>
+    /// Handles the event when a file is moved.
+    /// </summary>
+    /// <param name="sender">The source of the event.</param>
+    /// <param name="args">Event arguments containing the old and new name of the file.</param>
+    private void OnMoved(object sender, MovedEventArgs args)
+        => OnFileSystemEvent(args, args.OldFullPath, () => Moved?.Invoke(this, args), () =>
         {
-            if (!IsWatchingFile(path) || !TryUpdateLastWriteTime(path))
-                return;
-        }
-
-        Changed?.Invoke(this, args);
-    }
+            _files.Remove(Path.GetFullPath(args.OldFullPath));
+            _files.Add(Path.GetFullPath(args.FullPath));
+        });
 
     /// <summary>
     /// Handles the event when a file is renamed.
@@ -236,36 +162,7 @@ internal sealed class FileWatcher : IDisposable
     /// <param name="sender">The source of the event.</param>
     /// <param name="args">Event arguments containing the old and new name of the file.</param>
     private void OnRenamed(object sender, RenamedEventArgs args)
-        => OnMoved(args.FullPath, args.OldFullPath);
-
-    /// <summary>
-    /// Processes the movement of a file and updates the internal list of files being watched.
-    /// </summary>
-    /// <param name="newFullPath">The new full path of the file.</param>
-    /// <param name="oldFullPath">The old full path of the file.</param>
-    private void OnMoved(string newFullPath, string oldFullPath)
-    {
-        if (!IsFileIncluded(newFullPath) || !IsFileIncluded(oldFullPath))
-        {
-            return;
-        }
-        LoggingHelper.Logger?.Log(this, "File moved: {0} -> {1}", GetRelativePath(oldFullPath), GetRelativePath(newFullPath));
-
-        newFullPath = Path.GetFullPath(newFullPath);
-        oldFullPath = Path.GetFullPath(oldFullPath);
-
-        lock (_lock)
-        {
-            if (!IsWatchingFile(oldFullPath) || !TryUpdateLastWriteTime(newFullPath))
-                return;
-
-            _files.Remove(oldFullPath);
-            _lastWriteTimes.Remove(oldFullPath);
-            _files.Add(newFullPath);
-        }
-
-        Moved?.Invoke(this, new(newFullPath, oldFullPath));
-    }
+        => OnMoved(sender, new(args.FullPath, args.OldFullPath));
 
     /// <summary>
     /// Handles any error that occurs during file watching.
@@ -276,46 +173,31 @@ internal sealed class FileWatcher : IDisposable
         => Error?.Invoke(this, args);
 
     /// <summary>
-    /// Adds an event to the internal buffer for further processing.
+    /// Handles a filesystem event, performing necessary actions based on the event type.
     /// </summary>
-    /// <param name="args">The event arguments to be buffered.</param>
-    private void BufferEvent(FileSystemEventArgs args)
+    /// <param name="args">The event arguments containing information about the filesystem operation.</param>
+    /// <param name="path">The path of the file associated with the event.</param>
+    /// <param name="handler">A handler for the event.</param>
+    /// <param name="sync">An action to synchronize changes after processing the event.</param>
+    private void OnFileSystemEvent(FileSystemEventArgs args, string path, Action? handler = null, Action? sync = null)
     {
-        long currentTimestamp = StopwatchHelper.GetTimestamp();
+        lock (_lock)
+        {
+            if (!IsWatchingFile(path))
+            {
+                _eventCache.Add(args);
+                return;
+            }
 
-        _eventBuffer.Add((args, currentTimestamp));
-    }
+            if (IsDuplicateEvent(args))
+                return;
 
-    /// <summary>
-    /// Removes stale events from the internal buffer.
-    /// </summary>
-    private void CleanupEventBuffer()
-    {
-        long currentTimestamp = StopwatchHelper.GetTimestamp();
+            _eventCache.Add(args);
+            sync?.Invoke();
+        }
 
-        _eventBuffer.RemoveAll(x => StopwatchHelper.GetElapsedTime(x.Timestamp, currentTimestamp).TotalMilliseconds > EventBufferLifetime);
-    }
-
-    /// <summary>
-    /// Attempts to update the last write time for the specified file and validates if it should trigger further actions.
-    /// </summary>
-    /// <param name="fileName">The name of the file to update.</param>
-    /// <returns>
-    /// <c>true</c> if the last write time was successfully updated and meets the criteria for an action;
-    /// otherwise, <c>false</c>.
-    /// </returns>
-    private bool TryUpdateLastWriteTime(string fileName)
-    {
-        DateTime newWriteTime = string.IsNullOrEmpty(fileName) ? default : File.GetLastWriteTime(fileName);
-
-        if (!_lastWriteTimes.TryGetValue(fileName, out DateTime lastWriteTime))
-            lastWriteTime = default;
-
-        if (newWriteTime == lastWriteTime)
-            return false;
-
-        _lastWriteTimes[fileName] = newWriteTime;
-        return (newWriteTime - lastWriteTime).TotalMilliseconds >= MinWriteTimeDifference;
+        if (!TryProcessComplexEvent(args))
+            handler?.Invoke();
     }
 
     /// <summary>
@@ -324,7 +206,129 @@ internal sealed class FileWatcher : IDisposable
     /// <param name="fileName">The name of the file to check.</param>
     /// <returns><c>true</c> if the file is being watched; otherwise, <c>false</c>.</returns>
     private bool IsWatchingFile(string fileName)
-        => _files.Contains(fileName);
+        => _files.Contains(Path.GetFullPath(fileName));
+
+    /// <summary>
+    /// Checks if the given filesystem event is a duplicate of any previously cached event.
+    /// </summary>
+    /// <param name="args">The event arguments containing information about the filesystem operation.</param>
+    /// <returns><c>true</c> if the event is a duplicate; otherwise, <c>false</c>.</returns>
+    private bool IsDuplicateEvent(FileSystemEventArgs args)
+    {
+        WatcherChangeTypes type = args.ChangeType;
+        string path = Path.GetFullPath(args.FullPath);
+        StringComparer fileNameComparer = FileHelper.FileNameComparer;
+
+        return _eventCache.Any(x => x.ChangeType == type && fileNameComparer.Equals(Path.GetFullPath(x.FullPath), path));
+    }
+
+    /// <summary>
+    /// Tries to process complex filesystem events that combine multiple atomic operations.
+    /// </summary>
+    /// <param name="args">The event arguments containing information about the filesystem operation.</param>
+    /// <returns><c>true</c> if a complex event (change or move operation) was successfully processed; otherwise, <c>false</c>.</returns>
+    private bool TryProcessComplexEvent(FileSystemEventArgs args)
+        => TryProcessComplexChange(args) || TryProcessComplexMove(args);
+
+    /// <summary>
+    /// Tries to process a complex move operation that involves copying a file to a new destination and then deleting the original.
+    /// </summary>
+    /// <remarks>
+    /// Such operation involves the following steps:
+    /// <list type="number">
+    /// <item>
+    /// <description>A file is created at a new location, effectively copying the original file (e.g., `Source.axaml` -> `Target.axaml`).</description>
+    /// </item>
+    /// <item>
+    /// <description>The original file is deleted (e.g., `Source.axaml` is deleted).</description>
+    /// </item>
+    /// </list>
+    /// Instead of emitting a separate 'created' event for the new location, and a 'deleted' event for the original location,
+    /// this method consolidates them and emits a single 'moved' event.
+    /// </remarks>
+    /// <param name="args">The event arguments containing information about the filesystem operation.</param>
+    /// <returns><c>true</c> if a complex move operation was successfully processed; otherwise, <c>false</c>.</returns>
+    private bool TryProcessComplexMove(FileSystemEventArgs args)
+    {
+        if (args.ChangeType is not (WatcherChangeTypes.Created or WatcherChangeTypes.Deleted))
+            return false;
+
+        WatcherChangeTypes oppositeChangeType = args.ChangeType is WatcherChangeTypes.Created ? WatcherChangeTypes.Deleted : WatcherChangeTypes.Created;
+        string fileName = Path.GetFileName(args.FullPath);
+        StringComparer fileNameComparer = FileHelper.FileNameComparer;
+        string? newFullPath = null;
+        string? oldFullPath = null;
+
+        lock (_lock)
+        {
+            FileSystemEventArgs? oppositeEvent = _eventCache.FirstOrDefault(x => x.ChangeType == oppositeChangeType && fileNameComparer.Equals(Path.GetFileName(x.FullPath), fileName));
+            if (oppositeEvent is null)
+                return false;
+
+            (newFullPath, oldFullPath) = args.ChangeType is WatcherChangeTypes.Created
+                ? (args.FullPath, oppositeEvent.FullPath)
+                : (oppositeEvent.FullPath, args.FullPath);
+        }
+
+        OnMoved(this, new(newFullPath, oldFullPath));
+        return true;
+    }
+
+    /// <summary>
+    /// Tries to process a complex file modification operation that is commonly performed by some IDEs, such as Visual Studio.
+    /// </summary>
+    /// <remarks>
+    /// Such operation involves several steps:
+    /// <list type="number">
+    /// <item>
+    /// <description>A copy of the original file is created (e.g., `mgwudjxu.mzo-`). This file will temporarily store applied changes.</description>
+    /// </item>
+    /// <item>
+    /// <description>Changes are applied to the copy.</description>
+    /// </item>
+    /// <item>
+    /// <description>The original file is given a temporary and randomly assigned filename (e.g., `MainWindow.axaml-RF44d4e140.TMP`).</description>
+    /// </item>
+    /// <item>
+    /// <description>The edited copy is moved back to the original file's location (`mgwudjxu.mzo-` -> `MainWindow.axaml`).</description>
+    /// </item>
+    /// <item>
+    /// <description>If no errors occurred during the process, the original file is deleted (`MainWindow.axaml-RF44d4e140.TMP`).</description>
+    /// </item>
+    /// </list>
+    /// In contrast to responding to each individual event, this method cumulatively processes them and emits a single "changed" event.
+    /// </remarks>
+    /// <param name="args">The event arguments containing information about the filesystem operation.</param>
+    /// <returns><c>true</c> if a complex change operation was successfully processed; otherwise, <c>false</c>.</returns>
+    private bool TryProcessComplexChange(FileSystemEventArgs args)
+    {
+        if (args.ChangeType is not WatcherChangeTypes.Deleted)
+            return false;
+
+        string path = Path.GetFullPath(args.FullPath);
+        StringComparer fileNameComparer = FileHelper.FileNameComparer;
+        string? previousPath;
+        lock (_lock)
+        {
+            previousPath = _eventCache
+                .OfType<MovedEventArgs>()
+                .FirstOrDefault(x => fileNameComparer.Equals(Path.GetFullPath(x.FullPath), path))?.OldFullPath;
+        }
+
+        if (!File.Exists(previousPath))
+            return false;
+
+        previousPath = Path.GetFullPath(previousPath);
+        lock (_lock)
+        {
+            _files.Remove(path);
+            _files.Add(previousPath);
+        }
+
+        Moved?.Invoke(this, new(previousPath, path));
+        Changed?.Invoke(this, new(WatcherChangeTypes.Changed, Path.GetDirectoryName(previousPath), Path.GetFileName(previousPath)));
+        return true;
+    }
 
     /// <summary>
     /// Disposes resources used by this file watcher.
@@ -346,7 +350,7 @@ internal sealed class FileWatcher : IDisposable
         {
             EnableRaisingEvents = false,
             IncludeSubdirectories = true,
-            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime
+            NotifyFilter = NotifyFilters.LastWrite
                 | NotifyFilters.DirectoryName
                 | NotifyFilters.FileName,
         };
@@ -358,24 +362,6 @@ internal sealed class FileWatcher : IDisposable
         watcher.EnableRaisingEvents = true;
 
         return watcher;
-    }
-
-    private string GetRelativePath(string path)
-    {
-        if (path.StartsWith(DirectoryName, StringComparison.OrdinalIgnoreCase))
-        {
-            return path.Substring(DirectoryName.Length);
-        }
-        return path;
-    }
-
-    private bool IsFileIncluded(string fileName)
-    {
-        if (_extensionsToWatch == null)
-        {
-            return true;
-        }
-        return _extensionsToWatch.Contains(Path.GetExtension(fileName), StringComparer.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/HotAvalonia/IO/FileWatcher.cs
+++ b/src/HotAvalonia/IO/FileWatcher.cs
@@ -215,6 +215,16 @@ internal sealed class FileWatcher : IDisposable
     /// <returns><c>true</c> if the event is a duplicate; otherwise, <c>false</c>.</returns>
     private bool IsDuplicateEvent(FileSystemEventArgs args)
     {
+        // Currently, we only care about filtering duplicate change events:
+        // - They trigger most of the unnecessary work.
+        // - They are the most straightforward ones to detect.
+        //
+        // Since duplicates of other events don't cause as much harm,
+        // let's just skip them for now and return to this matter later,
+        // if it becomes a problem.
+        if (args.ChangeType is not WatcherChangeTypes.Changed)
+            return false;
+
         WatcherChangeTypes type = args.ChangeType;
         string path = Path.GetFullPath(args.FullPath);
         StringComparer fileNameComparer = FileHelper.FileNameComparer;


### PR DESCRIPTION
Here is what happens when user saves file.axaml with some changes:

```
A:create and fill a.tmp with changed content
B:move file.axaml -> file.axml.tmp
C:move a.tmp -> file.axaml
```

So the problem was that FileWatcher._files contained name like `\Views\MainWindow.axaml~RF44d4e140.TMP` after B

Therefore I decided to watch only .axaml files. Not ideal solution but don't have better idea for now
Also added logging to let user know that change was observed.

Here is the full log of what happens without filtering files:
```
18:09:02:000	[HotReload]File created: '\Views\mgwudjxu.mzo~'(FileWatcher #39086322)
18:09:02:000	[HotReload]File changed: '\Views\mgwudjxu.mzo~', change type: 'Changed'(FileWatcher #39086322)
18:09:02:000	[HotReload]File changed: '\Views\mgwudjxu.mzo~', change type: 'Changed'(FileWatcher #39086322)
18:09:02:000	[HotReload]File created: '\Views\MainWindow.axaml~RF44d4e140.TMP'(FileWatcher #39086322)
18:09:02:000	[HotReload]File deleted: '\Views\MainWindow.axaml~RF44d4e140.TMP'(FileWatcher #39086322)
18:09:02:000	[HotReload]File moved: '\Views\MainWindow.axaml~RF44d4e140.TMP' -> '\Views\MainWindow.axaml~RF44d4e140.TMP'(FileWatcher #39086322)
18:09:02:000	[HotReload]File moved: '\Views\MainWindow.axaml' -> '\Views\MainWindow.axaml~RF44d4e140.TMP'(FileWatcher #39086322)
18:09:02:000	[HotReload]File moved: '\Views\mgwudjxu.mzo~' -> '\Views\MainWindow.axaml'(FileWatcher #39086322)
18:09:02:000	[HotReload]File changed: '\Views\MainWindow.axaml~RF44d4e140.TMP', change type: 'Changed'(FileWatcher #39086322)
18:09:02:000	[HotReload]File changed: '\Views\MainWindow.axaml', change type: 'Changed'(FileWatcher #39086322)
18:09:02:000	[HotReload]File deleted: '\Views\MainWindow.axaml~RF44d4e140.TMP'(FileWatcher #39086322)
18:09:02:000	[HotReload]File moved: '\Views\MainWindow.axaml~RF44d4e140.TMP' -> '\Views\MainWindow.axaml~RF44d4e140.TMP'(FileWatcher #39086322)
```

After my change it becomes:

`19:31:57:885	[HotReload]File changed: '\Views\MainWindow.axaml', change type: 'Changed'(FileWatcher #45653674)
`

---

Fixes #3