### PR TITLE
Add missing `using System` in `AvaloniaHotReloadExtensions.cs`

### DIFF
--- a/src/HotAvalonia.Extensions/AvaloniaHotReloadExtensions.cs
+++ b/src/HotAvalonia.Extensions/AvaloniaHotReloadExtensions.cs
@@ -147,6 +147,7 @@ namespace HotAvalonia
 #else
 namespace HotAvalonia
 {
+    using global::System;
     using global::System.Diagnostics;
     using global::System.Diagnostics.CodeAnalysis;
     using global::System.Reflection;


### PR DESCRIPTION
Prevents a compilation error similar to:

> packages\hotavalonia.extensions\2.0.0\contentFiles\cs\any\AvaloniaHotReloadExtensions.cs(179,66): error CS0246: The type or namespace name 'Func<,>' could not be found (are you missing a using directive or an assembly reference?)
