### PR TITLE
Updated installation section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ If you have a multi-project setup, it is **highly recommended** to add `HotAvalo
 
 `HotAvalonia` is a development-only dependency, meaning it doesn't affect your Release builds in any way, shape, or form, and its binaries are **not** shipped with your application.
 
+> [!IMPORTANT]
+> If you install `HotAvalonia` using the built-in **NuGet UI** in `Visual Studio` or `Rider`, it adds an `IncludeAssets` attribute to the `PackageReference`.
+>
+> This breaks the build — you will need to manually remove that attribute from your `.csproj` file to make the project compile.
+
 ----
 
 ## Examples


### PR DESCRIPTION
Fixes #39.

This PR updates the `HotAvalonia.targets` file to respect the newly added `HotAvaloniaOverrideIncludeAssets` property.
By default, it removes the `IncludeAssets` setting from the `HotAvalonia` package reference **at build time**, without modifying the target project `.csproj` file.
If `HotAvaloniaOverrideIncludeAssets` is set to `false`, the `IncludeAssets` setting is left untouched.