### PR TITLE
Add host-compiled XAML hot reload for iOS

### DIFF
--- a/HotAvalonia.slnx
+++ b/HotAvalonia.slnx
@@ -8,6 +8,7 @@
 
   <Folder Name="/tools/">
     <Project Path="src/HotAvalonia.Remote/HotAvalonia.Remote.csproj" />
+    <Project Path="src/HotAvalonia.HostCompiler/HotAvalonia.HostCompiler.csproj" />
   </Folder>
 
   <Folder Name="/samples/">

--- a/samples/host-compiled/README.md
+++ b/samples/host-compiled/README.md
@@ -1,0 +1,55 @@
+# Host-compiled hot reload (iOS) — quick start
+
+On iOS, XAML can't be compiled on-device (no runtime `Reflection.Emit`). HotAvalonia handles this by
+**compiling each changed view on the host** into a `<view>.axaml.hotreload.dll` sidecar that the device
+loads and applies. Two host-side processes make that work:
+
+- **HARFS** (`HotAvalonia.Remote`) — serves your source files to the device.
+- **Host compiler** (`HotAvalonia.HostCompiler`) — watches `.axaml` files and compiles each change.
+
+Both ship in the `HotAvalonia` NuGet package's `tools/` folder. They are **dev-time host processes**, not
+part of your build — start them once, then edit XAML freely (no rebuild).
+
+## Prerequisites
+- macOS + the .NET SDK (iOS apps build only on a Mac).
+- The `HotAvalonia` package referenced in your iOS app + Avalonia views projects (`PrivateAssets="All"`).
+- The app **built + deployed once** (so the compiler can auto-discover its reference closure), device on the
+  same Wi-Fi/subnet (VPN off) for a real device.
+
+## 90% case — one command
+```bash
+samples/host-compiled/hotreload.sh --app-project path/to/YourApp.iOS.csproj
+```
+Starts HARFS + the compiler (each only if not already running; Ctrl-C stops what it started). Then deploy a
+Debug build, and edit any `.axaml`.
+
+Useful flags:
+- `--no-harfs` — you run your own HARFS server; just start the compiler.
+- `--no-compiler` — start only HARFS.
+- `--bind 127.0.0.1` — simulator (default `0.0.0.0` targets a real device over the LAN).
+- `--views-dir <dir>`, `--port <n>`, `--secret <s>` — override the defaults.
+
+No code is required in a stock Avalonia app — the weaver auto-enables hot reload, `UseHostCompiledXaml`
+defaults on for iOS, and the views' source root is baked into the assembly (no `ProjectLocator.AddHint`).
+
+## 10% case — roll your own
+Everything is a plain CLI/API, so you can script your own loop:
+```bash
+# 1. Serve sources to the device
+dotnet <pkg>/tools/HotAvalonia.Remote.dll --root <repo> --endpoint 0.0.0.0:9500 --secret text:<secret>
+# 2. Compile each changed view (auto-discovers closure + Avalonia version from the app project)
+dotnet <pkg>/tools/HotAvalonia.HostCompiler.dll watch <views-dir> --app-project <App.iOS.csproj>
+#    (one-shot: `compile <view.axaml> --app-project <App.iOS.csproj>`; explicit inputs:
+#     `--closure <dir> --avalonia-version <ver>`)
+```
+A custom app bootstrap (one that doesn't use a virtual `CustomizeAppBuilder`) enables hot reload itself:
+```csharp
+var fs = HotAvalonia.IO.FileSystem.Connect(macEndpoint, secret, fallbackFileSystem: HotAvalonia.IO.FileSystem.Empty);
+var config = HotAvalonia.AvaloniaHotReloadConfig.Default with { FileSystem = fs };  // UseHostCompiledXaml defaults true on iOS
+HotAvalonia.AvaloniaHotReloadContext.FromAppDomain(config).EnableHotReload();
+```
+
+## Notes
+- The script reuses an already-running HARFS/compiler instead of starting a duplicate.
+- Tool paths resolve from the newest cached `hotavalonia` package; override with `HARFS_DLL` /
+  `HOSTCOMPILER_DLL` (e.g. to point at a local build output).

--- a/samples/host-compiled/hotreload.sh
+++ b/samples/host-compiled/hotreload.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# hotreload.sh - one-shot launcher for HotAvalonia host-compiled hot reload (iOS).
+#
+# Starts the HARFS file server and the host-side XAML compiler (watch mode), each ONLY if it isn't
+# already running, then waits. Leave it in a terminal; Ctrl-C stops whatever THIS script started
+# (an already-running server/watcher is reused, not killed). iOS host-compiled hot reload is
+# macOS-only - you can only build iOS apps on a Mac. It is NOT tied to your build: start it once,
+# then edit .axaml files freely (no rebuild needed).
+#
+# Usage:
+#   hotreload.sh --app-project <App.csproj> [options]
+#
+# Options:
+#   --app-project <csproj>  The iOS app project (required; the compiler discovers the build closure from it).
+#   --views-dir <dir>       Directory of .axaml files to watch (default: the app project's git repo root).
+#   --bind <addr>           HARFS bind address (default: 0.0.0.0 = LAN/real device; use 127.0.0.1 for the simulator).
+#   --port <n>              HARFS port (default: 9500).
+#   --secret <s>            HARFS shared secret (default: hotavalonia-dev).
+#   --no-harfs              Don't start HARFS (e.g. you run your own server).
+#   --no-compiler           Don't start the host compiler watcher.
+#
+# Tool resolution: HotAvalonia.Remote.dll / HotAvalonia.HostCompiler.dll are taken from the newest cached
+# `hotavalonia` NuGet package's tools/ folder. Override with the HARFS_DLL / HOSTCOMPILER_DLL env vars
+# (e.g. to point at a local build output).
+#
+# Prerequisite: build + deploy the app once first, so the compiler can auto-discover its reference closure.
+set -euo pipefail
+
+APP_PROJECT=""
+VIEWS_DIR=""
+BIND="0.0.0.0"
+PORT="9500"
+SECRET="hotavalonia-dev"
+START_HARFS=1
+START_COMPILER=1
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --app-project) APP_PROJECT="$2"; shift 2;;
+    --views-dir)   VIEWS_DIR="$2"; shift 2;;
+    --bind)        BIND="$2"; shift 2;;
+    --port)        PORT="$2"; shift 2;;
+    --secret)      SECRET="$2"; shift 2;;
+    --no-harfs)    START_HARFS=0; shift;;
+    --no-compiler) START_COMPILER=0; shift;;
+    -h|--help)     sed -n '2,30p' "$0"; exit 0;;
+    *) echo "unknown option: $1" >&2; exit 2;;
+  esac
+done
+
+[ -n "$APP_PROJECT" ] || { echo "error: --app-project <csproj> is required (use --help)" >&2; exit 2; }
+[ -f "$APP_PROJECT" ] || { echo "error: app project not found: $APP_PROJECT" >&2; exit 2; }
+APP_PROJECT="$(cd "$(dirname "$APP_PROJECT")" && pwd)/$(basename "$APP_PROJECT")"
+
+REPO_ROOT="$(git -C "$(dirname "$APP_PROJECT")" rev-parse --show-toplevel 2>/dev/null || dirname "$APP_PROJECT")"
+VIEWS_DIR="${VIEWS_DIR:-$REPO_ROOT}"
+
+NUGET="${NUGET_PACKAGES:-$HOME/.nuget/packages}"
+find_tool() { ls -d "$NUGET"/hotavalonia/*/tools/"$1" 2>/dev/null | sort -V | tail -1 || true; }
+HARFS_DLL="${HARFS_DLL:-$(find_tool HotAvalonia.Remote.dll)}"
+HOSTCOMPILER_DLL="${HOSTCOMPILER_DLL:-$(find_tool HotAvalonia.HostCompiler.dll)}"
+
+PIDS=()
+cleanup() { [ ${#PIDS[@]} -gt 0 ] && kill "${PIDS[@]}" 2>/dev/null || true; }
+trap cleanup EXIT
+trap 'exit 0' INT TERM HUP
+
+# --- HARFS: start only if the port isn't already served ---
+if [ "$START_HARFS" -eq 1 ]; then
+  if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    echo ">>> HARFS: already listening on :$PORT - reusing it."
+  else
+    [ -n "$HARFS_DLL" ] && [ -f "$HARFS_DLL" ] || { echo "error: HotAvalonia.Remote.dll not found - set HARFS_DLL." >&2; exit 1; }
+    echo ">>> HARFS: starting on $BIND:$PORT (root=$REPO_ROOT)"
+    dotnet "$HARFS_DLL" --root "$REPO_ROOT" --endpoint "$BIND:$PORT" --secret "text:$SECRET" &
+    PIDS+=($!)
+  fi
+fi
+
+# --- host compiler watch: start only if not already watching this app ---
+if [ "$START_COMPILER" -eq 1 ]; then
+  LOCK="${TMPDIR:-/tmp}/hotavalonia-hostcompiler-$(echo "$APP_PROJECT" | shasum | cut -c1-8).pid"
+  if [ -f "$LOCK" ] && kill -0 "$(cat "$LOCK" 2>/dev/null)" 2>/dev/null; then
+    echo ">>> Host compiler: already watching this app (pid $(cat "$LOCK")) - skipping."
+  else
+    [ -n "$HOSTCOMPILER_DLL" ] && [ -f "$HOSTCOMPILER_DLL" ] || { echo "error: HotAvalonia.HostCompiler.dll not found - set HOSTCOMPILER_DLL." >&2; exit 1; }
+    echo ">>> Host compiler: watching $VIEWS_DIR (app=$(basename "$APP_PROJECT"))"
+    dotnet "$HOSTCOMPILER_DLL" watch "$VIEWS_DIR" --app-project "$APP_PROJECT" &
+    CPID=$!; PIDS+=($CPID); echo "$CPID" > "$LOCK"
+    ( wait "$CPID" 2>/dev/null; rm -f "$LOCK" ) &
+  fi
+fi
+
+[ ${#PIDS[@]} -eq 0 ] && { echo "Nothing to start (already running, or both disabled)."; exit 0; }
+echo ">>> Running. Ctrl-C to stop. Edit a Mobile .axaml to test."
+wait

--- a/src/HotAvalonia.Core/AvaloniaControlManager.cs
+++ b/src/HotAvalonia.Core/AvaloniaControlManager.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Reflection;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.LogicalTree;
@@ -86,6 +87,35 @@ internal sealed class AvaloniaControlManager : IDisposable
         cancellationToken.ThrowIfCancellationRequested();
         CompiledXamlDocument compiledXaml = XamlCompiler.Compile(xaml, _document._uri, _document._rootType.Assembly);
         _recompiledDocument = new(compiledXaml._uri, compiledXaml._build, compiledXaml._populate, compiledXaml._populateOverride, _document._refresh);
+    }
+
+    /// <summary>
+    /// Asynchronously reloads the controls from a host-compiled (Mac-produced) populate assembly,
+    /// bypassing the on-device XAML compiler (which relies on Reflection.Emit, unavailable on iOS).
+    /// </summary>
+    /// <param name="assemblyBytes">The raw bytes of the host-compiled populate assembly.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    public Task ReloadFromAssemblyAsync(byte[] assemblyBytes, CancellationToken cancellationToken = default)
+        => Dispatcher.UIThread.InvokeAsync(() => ReloadFromAssembly(assemblyBytes, cancellationToken), DispatcherPriority.Render, cancellationToken).GetTask();
+
+    private void ReloadFromAssembly(byte[] assemblyBytes, CancellationToken cancellationToken)
+    {
+        RecompileFromAssembly(assemblyBytes, cancellationToken);
+        Reload(cancellationToken);
+    }
+
+    private void RecompileFromAssembly(byte[] assemblyBytes, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Assembly.Load(byte[]) is supported under the iOS Mono interpreter (read-only load; no Reflection.Emit).
+        Assembly assembly = Assembly.Load(assemblyBytes);
+        if (!HostCompiledXamlLoader.TryFindResourceMethods(assembly, _document._rootType, out MethodBase build, out MethodInfo populate))
+            throw new InvalidOperationException($"Host-compiled assembly '{assembly.GetName().Name}' has no build/populate pair for '{_document._rootType}'.");
+
+        // Reuse the original document's populate-override field (the live device type's
+        // !XamlIlPopulateOverride) and refresh delegate; only the build/populate logic is swapped.
+        _recompiledDocument = new(_document._uri, build, populate, _document._populateOverride, _document._refresh);
     }
 
     private void Reload(string xaml, CancellationToken cancellationToken)

--- a/src/HotAvalonia.Core/AvaloniaHotReloadConfig.cs
+++ b/src/HotAvalonia.Core/AvaloniaHotReloadConfig.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Runtime.InteropServices;
 using HotAvalonia.DependencyInjection;
 using HotAvalonia.IO;
 using HotAvalonia.Xaml;
@@ -59,6 +60,21 @@ public sealed record class AvaloniaHotReloadConfig
     }
 
     /// <summary>
+    /// Whether the current OS forbids runtime code generation (Reflection.Emit), making host-compiled
+    /// reload the only viable option. <c>true</c> on iOS.
+    /// </summary>
+    private static readonly bool s_requiresHostCompiledXaml = RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"));
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to reload from host-compiled populate assemblies fetched
+    /// over the file system instead of compiling XAML on-device. Required on iOS, where the on-device XAML
+    /// compiler (Reflection.Emit) is unavailable — so this defaults to <c>true</c> on iOS and <c>false</c>
+    /// elsewhere. The host publishes a DLL next to each changed view as
+    /// <c>&lt;view&gt;.axaml.hotreload.dll</c>, produced by a host-side watch/compile step.
+    /// </summary>
+    public bool UseHostCompiledXaml { get; init; } = s_requiresHostCompiledXaml;
+
+    /// <summary>
     /// Gets or sets the hot reload mode.
     /// </summary>
     public HotReloadMode Mode { get; init; } = HotReloadMode.Minimal;
@@ -79,7 +95,8 @@ public sealed record class AvaloniaHotReloadConfig
         bool? skipInitialPatching = null,
         AvaloniaProjectLocator? projectLocator = null,
         HotReloadMode? mode = null,
-        TimeSpan? timeout = null
+        TimeSpan? timeout = null,
+        bool? useHostCompiledXaml = null
     ) => this with
     {
         AppDomain = appDomain ?? AppDomain,
@@ -89,5 +106,6 @@ public sealed record class AvaloniaHotReloadConfig
         ProjectLocator = projectLocator ?? ProjectLocator,
         Mode = mode ?? Mode,
         Timeout = timeout ?? Timeout,
+        UseHostCompiledXaml = useHostCompiledXaml ?? UseHostCompiledXaml,
     };
 }

--- a/src/HotAvalonia.Core/AvaloniaProjectHotReloadContext.cs
+++ b/src/HotAvalonia.Core/AvaloniaProjectHotReloadContext.cs
@@ -99,7 +99,7 @@ internal sealed class AvaloniaProjectHotReloadContext : IHotReloadContext, ISupp
         _controls.Clear();
     }
 
-    private void OnChanged(object sender, FileSystemEventArgs args)
+    private void OnChanged(object sender, FileChangeEventArgs args)
     {
         if (!IsHotReloadEnabled)
             return;
@@ -107,7 +107,7 @@ internal sealed class AvaloniaProjectHotReloadContext : IHotReloadContext, ISupp
         _ = RunWithDefaultTimeoutAsync(cancellationToken => ReloadAsync(args.FullPath, cancellationToken));
     }
 
-    private void OnRenamed(object sender, RenamedEventArgs args)
+    private void OnRenamed(object sender, FileRenameEventArgs args)
     {
         string newFullPath = args.FullPath;
         string oldFullPath = args.OldFullPath;
@@ -119,8 +119,8 @@ internal sealed class AvaloniaProjectHotReloadContext : IHotReloadContext, ISupp
         _controls[newFullPath] = controlManager;
     }
 
-    private void OnError(object sender, ErrorEventArgs args)
-        => Logger.LogError(sender, "An unexpected error occurred while monitoring file changes: {Exception}", args.GetException());
+    private void OnError(object sender, Exception error)
+        => Logger.LogError(sender, "An unexpected error occurred while monitoring file changes: {Exception}", error);
 
     private async Task ReloadAsync(string path, CancellationToken cancellationToken)
     {
@@ -133,6 +133,14 @@ internal sealed class AvaloniaProjectHotReloadContext : IHotReloadContext, ISupp
         {
             if (!await fileSystem.FileExistsAsync(fullPath, cancellationToken).ConfigureAwait(false))
                 return;
+
+            // iOS path: the on-device XAML compiler can't run (Reflection.Emit), so reload from the
+            // Mac-compiled populate DLL published next to the view instead of compiling XAML here.
+            if (Config.UseHostCompiledXaml)
+            {
+                await ReloadFromHostCompiledAsync(control, fullPath, cancellationToken).ConfigureAwait(false);
+                return;
+            }
 
             Type controlType = control.Document.RootType;
             bool isApp = typeof(Application).IsAssignableFrom(controlType);
@@ -170,6 +178,48 @@ internal sealed class AvaloniaProjectHotReloadContext : IHotReloadContext, ISupp
         {
             Logger.LogError(this, "Failed to reload '{Uri}': {Exception}", control.Document.Uri, e);
         }
+    }
+
+    private async Task ReloadFromHostCompiledAsync(AvaloniaControlManager control, string axamlPath, CancellationToken cancellationToken)
+    {
+        IFileSystem fileSystem = Config.FileSystem;
+        string dllPath = axamlPath + HostCompiledXamlNaming.SidecarSuffix;
+        DateTime axamlTime = await fileSystem.GetLastWriteTimeUtcAsync(axamlPath, cancellationToken).ConfigureAwait(false);
+
+        byte[]? assemblyBytes = await WaitForFreshAssemblyAsync(fileSystem, dllPath, axamlTime, cancellationToken).ConfigureAwait(false);
+        if (assemblyBytes is null)
+        {
+            Logger.LogError(this, "Timed out waiting for host-compiled '{Path}'. Is the host watch/compile step running?", dllPath);
+            return;
+        }
+
+        Logger.LogInfo(this, "Reloading '{Uri}' from host-compiled assembly ({Size} bytes)...", control.Document.Uri, assemblyBytes.Length);
+        await control.ReloadFromAssemblyAsync(assemblyBytes, cancellationToken).ConfigureAwait(false);
+        TriggerHotReload();
+    }
+
+    // The Mac compiles asynchronously (~3-5 s), so the freshly published DLL lags the .axaml save.
+    // Poll until a DLL at least as new as the edit shows up (~20 s budget), then read its bytes.
+    private static async Task<byte[]?> WaitForFreshAssemblyAsync(IFileSystem fileSystem, string dllPath, DateTime notBeforeUtc, CancellationToken cancellationToken)
+    {
+        DateTime threshold = notBeforeUtc - TimeSpan.FromSeconds(2);
+        for (int attempt = 0; attempt < 40; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (await fileSystem.FileExistsAsync(dllPath, cancellationToken).ConfigureAwait(false))
+            {
+                DateTime dllTime = await fileSystem.GetLastWriteTimeUtcAsync(dllPath, cancellationToken).ConfigureAwait(false);
+                if (dllTime >= threshold)
+                {
+                    using System.IO.Stream stream = await fileSystem.OpenReadAsync(dllPath, cancellationToken).ConfigureAwait(false);
+                    using System.IO.MemoryStream buffer = new();
+                    await stream.CopyToAsync(buffer, 81920, cancellationToken).ConfigureAwait(false);
+                    return buffer.ToArray();
+                }
+            }
+            await Task.Delay(500, cancellationToken).ConfigureAwait(false);
+        }
+        return null;
     }
 
     private async Task PatchAsync(AvaloniaControlManager controlManager, string path, CancellationToken cancellationToken)

--- a/src/HotAvalonia.Core/AvaloniaProjectLocator.cs
+++ b/src/HotAvalonia.Core/AvaloniaProjectLocator.cs
@@ -50,6 +50,7 @@ public sealed class AvaloniaProjectLocator
         _fileSystem = fileSystem;
         _cache = new();
         _hints = new();
+        AddHint(GetSourceRootFromMetadata);
     }
 
     /// <summary>
@@ -116,6 +117,29 @@ public sealed class AvaloniaProjectLocator
         Assembly assembly = type.Assembly;
         string directoryName = UriHelper.ResolveHostPath(uri, fileName);
         AddHint(assembly, directoryName);
+    }
+
+    /// <summary>
+    /// The <see cref="AssemblyMetadataAttribute"/> key under which the build bakes a project's source
+    /// root, letting the locator find the source even when the debug info that normally carries it is
+    /// stripped (e.g. by the iOS Full linker).
+    /// </summary>
+    private const string SourceRootMetadataKey = "HotAvalonia.SourceRoot";
+
+    /// <summary>
+    /// A built-in hint that reads the source root baked into the assembly by HotAvalonia's build targets.
+    /// </summary>
+    /// <param name="assembly">The assembly to inspect.</param>
+    /// <returns>The baked source root, or <c>null</c> if the assembly carries no such metadata.</returns>
+    private static string? GetSourceRootFromMetadata(Assembly assembly)
+    {
+        foreach (AssemblyMetadataAttribute attribute in assembly.GetCustomAttributes<AssemblyMetadataAttribute>())
+        {
+            if (SourceRootMetadataKey.Equals(attribute.Key, StringComparison.Ordinal))
+                return attribute.Value;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/HotAvalonia.Core/AvaloniaSolutionHotReloadContext.cs
+++ b/src/HotAvalonia.Core/AvaloniaSolutionHotReloadContext.cs
@@ -130,7 +130,10 @@ internal sealed class AvaloniaSolutionHotReloadContext : IHotReloadContext, ISup
     private void OnAssemblyLoad(object sender, AssemblyLoadEventArgs eventArgs)
     {
         Assembly? assembly = eventArgs?.LoadedAssembly;
-        if (assembly is null || !TryLoadAvaloniaProject(assembly, out AvaloniaProjectHotReloadContext? project))
+
+        // Host-compiled populate DLLs carry Avalonia documents too, but they're transient reload
+        // carriers, not projects to watch — skip them (also dodges a native Mono load-hook assertion on iOS).
+        if (assembly is null || Xaml.HostCompiledXamlLoader.IsHostCompiledAssembly(assembly) || !TryLoadAvaloniaProject(assembly, out AvaloniaProjectHotReloadContext? project))
             return;
 
         State state;

--- a/src/HotAvalonia.Core/IO/EmptyFileSystemWatcher.cs
+++ b/src/HotAvalonia.Core/IO/EmptyFileSystemWatcher.cs
@@ -38,19 +38,19 @@ internal sealed class EmptyFileSystemWatcher : IFileSystemWatcher
     }
 
     /// <inheritdoc/>
-    public event FileSystemEventHandler Created { add { } remove { } }
+    public event FileChangeEventHandler Created { add { } remove { } }
 
     /// <inheritdoc/>
-    public event FileSystemEventHandler Deleted { add { } remove { } }
+    public event FileChangeEventHandler Deleted { add { } remove { } }
 
     /// <inheritdoc/>
-    public event FileSystemEventHandler Changed { add { } remove { } }
+    public event FileChangeEventHandler Changed { add { } remove { } }
 
     /// <inheritdoc/>
-    public event RenamedEventHandler Renamed { add { } remove { } }
+    public event FileRenameEventHandler Renamed { add { } remove { } }
 
     /// <inheritdoc/>
-    public event ErrorEventHandler Error { add { } remove { } }
+    public event FileWatcherErrorEventHandler Error { add { } remove { } }
 
     /// <inheritdoc/>
     public void Dispose() { }

--- a/src/HotAvalonia.Core/IO/FileChange.cs
+++ b/src/HotAvalonia.Core/IO/FileChange.cs
@@ -1,0 +1,81 @@
+using System.IO;
+
+namespace HotAvalonia.IO;
+
+/// <summary>
+/// Describes a file system change.
+/// </summary>
+/// <remarks>
+/// iOS ships <c>System.IO.FileSystem.Watcher</c> as a throw-stub: <see cref="FileSystemEventArgs"/>'s
+/// constructor and <c>FullPath</c> getter both throw <see cref="PlatformNotSupportedException"/>, so the
+/// BCL event-arg types are unusable there. This is the platform-safe substitute carried through
+/// HotAvalonia's watcher abstraction. The <see cref="WatcherChangeTypes"/> enum itself is safe to use —
+/// only the classes in that assembly throw.
+/// </remarks>
+public class FileChangeEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileChangeEventArgs"/> class.
+    /// </summary>
+    /// <param name="changeType">The kind of change detected.</param>
+    /// <param name="fullPath">The fully qualified path of the affected file or directory.</param>
+    public FileChangeEventArgs(WatcherChangeTypes changeType, string fullPath)
+    {
+        ChangeType = changeType;
+        FullPath = fullPath;
+    }
+
+    /// <summary>
+    /// Gets the kind of change that occurred.
+    /// </summary>
+    public WatcherChangeTypes ChangeType { get; }
+
+    /// <summary>
+    /// Gets the fully qualified path of the affected file or directory.
+    /// </summary>
+    public string FullPath { get; }
+}
+
+/// <summary>
+/// Describes a file system rename.
+/// </summary>
+public sealed class FileRenameEventArgs : FileChangeEventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileRenameEventArgs"/> class.
+    /// </summary>
+    /// <param name="changeType">The kind of change detected.</param>
+    /// <param name="fullPath">The fully qualified path of the affected file or directory.</param>
+    /// <param name="oldFullPath">The previous fully qualified path of the affected file or directory.</param>
+    public FileRenameEventArgs(WatcherChangeTypes changeType, string fullPath, string oldFullPath)
+        : base(changeType, fullPath)
+    {
+        OldFullPath = oldFullPath;
+    }
+
+    /// <summary>
+    /// Gets the previous fully qualified path of the affected file or directory.
+    /// </summary>
+    public string OldFullPath { get; }
+}
+
+/// <summary>
+/// Represents the method that handles a <see cref="FileChangeEventArgs"/>.
+/// </summary>
+/// <param name="sender">The source of the event.</param>
+/// <param name="e">The change data.</param>
+public delegate void FileChangeEventHandler(object sender, FileChangeEventArgs e);
+
+/// <summary>
+/// Represents the method that handles a <see cref="FileRenameEventArgs"/>.
+/// </summary>
+/// <param name="sender">The source of the event.</param>
+/// <param name="e">The rename data.</param>
+public delegate void FileRenameEventHandler(object sender, FileRenameEventArgs e);
+
+/// <summary>
+/// Represents the method that handles a file watcher error.
+/// </summary>
+/// <param name="sender">The source of the event.</param>
+/// <param name="error">The error that occurred.</param>
+public delegate void FileWatcherErrorEventHandler(object sender, Exception error);

--- a/src/HotAvalonia.Core/IO/FileObserver.cs
+++ b/src/HotAvalonia.Core/IO/FileObserver.cs
@@ -7,7 +7,7 @@ namespace HotAvalonia.IO;
 /// Provides an observable mechanism for monitoring a file, notifying subscribers of updates.
 /// </summary>
 /// <typeparam name="T">The type of data provided to observers.</typeparam>
-internal sealed class FileObserver<T> : IObservable<T>, IObserver<FileSystemEventArgs>
+internal sealed class FileObserver<T> : IObservable<T>, IObserver<FileChangeEventArgs>
 {
     /// <summary>
     /// A function that provides the data to be observed.
@@ -42,7 +42,7 @@ internal sealed class FileObserver<T> : IObservable<T>, IObserver<FileSystemEven
         => _entries.GetOrAdd(observer, x => new(this, x));
 
     /// <inheritdoc/>
-    void IObserver<FileSystemEventArgs>.OnCompleted()
+    void IObserver<FileChangeEventArgs>.OnCompleted()
     {
         foreach (IObserver<T> observer in _entries.Keys)
         {
@@ -58,7 +58,7 @@ internal sealed class FileObserver<T> : IObservable<T>, IObserver<FileSystemEven
     }
 
     /// <inheritdoc/>
-    void IObserver<FileSystemEventArgs>.OnError(Exception error)
+    void IObserver<FileChangeEventArgs>.OnError(Exception error)
     {
         foreach (IObserver<T> observer in _entries.Keys)
         {
@@ -74,7 +74,7 @@ internal sealed class FileObserver<T> : IObservable<T>, IObserver<FileSystemEven
     }
 
     /// <inheritdoc/>
-    void IObserver<FileSystemEventArgs>.OnNext(FileSystemEventArgs value)
+    void IObserver<FileChangeEventArgs>.OnNext(FileChangeEventArgs value)
     {
         T nextValue;
         try
@@ -83,7 +83,7 @@ internal sealed class FileObserver<T> : IObservable<T>, IObserver<FileSystemEven
         }
         catch (Exception error)
         {
-            ((IObserver<FileSystemEventArgs>)this).OnError(error);
+            ((IObserver<FileChangeEventArgs>)this).OnError(error);
             return;
         }
 
@@ -189,7 +189,7 @@ file sealed class SharedFileObserver : IDisposable
     /// A dictionary that maintains a mapping of the monitored files to their
     /// corresponding observers.
     /// </summary>
-    private readonly ConcurrentDictionary<string, ConcurrentBag<WeakReference<IObserver<FileSystemEventArgs>>>> _observers;
+    private readonly ConcurrentDictionary<string, ConcurrentBag<WeakReference<IObserver<FileChangeEventArgs>>>> _observers;
 
     /// <summary>
     /// A synchronization lock for managing concurrent access
@@ -229,7 +229,7 @@ file sealed class SharedFileObserver : IDisposable
     /// <param name="observer">The observer to be notified of file events.</param>
     /// <param name="fileName">The name of the file to monitor.</param>
     /// <param name="fileSystem">The file system where <paramref name="fileName"/> can be found.</param>
-    public static void Subscribe(IObserver<FileSystemEventArgs> observer, string fileName, IFileSystem fileSystem)
+    public static void Subscribe(IObserver<FileChangeEventArgs> observer, string fileName, IFileSystem fileSystem)
     {
         ArgumentNullException.ThrowIfNull(observer);
         ArgumentNullException.ThrowIfNull(fileName);
@@ -245,7 +245,7 @@ file sealed class SharedFileObserver : IDisposable
     }
 
     /// <inheritdoc cref="Subscribe"/>
-    private void SubscribeCore(IObserver<FileSystemEventArgs> observer, string fileName)
+    private void SubscribeCore(IObserver<FileChangeEventArgs> observer, string fileName)
     {
         fileName = _watcher.FileSystem.GetFullPath(fileName);
         _observers.AddOrUpdate(
@@ -284,11 +284,11 @@ file sealed class SharedFileObserver : IDisposable
     /// </summary>
     /// <param name="sender">The source of the event.</param>
     /// <param name="args">The file system event data.</param>
-    private void OnChanged(object sender, FileSystemEventArgs args)
+    private void OnChanged(object sender, FileChangeEventArgs args)
     {
         OnNext(args.FullPath, args);
 
-        if (args is RenamedEventArgs renamedArgs)
+        if (args is FileRenameEventArgs renamedArgs)
             OnNext(renamedArgs.OldFullPath, renamedArgs);
     }
 
@@ -297,17 +297,17 @@ file sealed class SharedFileObserver : IDisposable
     /// </summary>
     /// <param name="fileName">The name of the file affected by the event.</param>
     /// <param name="args">The event data.</param>
-    private void OnNext(string fileName, FileSystemEventArgs args)
+    private void OnNext(string fileName, FileChangeEventArgs args)
     {
         fileName = FileSystem.GetFullPath(fileName);
-        if (!_observers.TryGetValue(fileName, out ConcurrentBag<WeakReference<IObserver<FileSystemEventArgs>>>? weakObservers))
+        if (!_observers.TryGetValue(fileName, out ConcurrentBag<WeakReference<IObserver<FileChangeEventArgs>>>? weakObservers))
             return;
 
         int hits = 0;
         int misses = 0;
-        foreach (WeakReference<IObserver<FileSystemEventArgs>> weakObserver in weakObservers)
+        foreach (WeakReference<IObserver<FileChangeEventArgs>> weakObserver in weakObservers)
         {
-            if (!weakObserver.TryGetTarget(out IObserver<FileSystemEventArgs>? observer) || observer is null)
+            if (!weakObserver.TryGetTarget(out IObserver<FileChangeEventArgs>? observer) || observer is null)
             {
                 ++misses;
                 continue;
@@ -334,8 +334,8 @@ file sealed class SharedFileObserver : IDisposable
         {
             _observers.AddOrUpdate(
                 fileName,
-                key => new(weakObservers.Where(static x => x.TryGetTarget(out IObserver<FileSystemEventArgs>? y) && y is not null)),
-                static (key, value) => new(value.Where(static x => x.TryGetTarget(out IObserver<FileSystemEventArgs>? y) && y is not null))
+                key => new(weakObservers.Where(static x => x.TryGetTarget(out IObserver<FileChangeEventArgs>? y) && y is not null)),
+                static (key, value) => new(value.Where(static x => x.TryGetTarget(out IObserver<FileChangeEventArgs>? y) && y is not null))
             );
         }
     }
@@ -345,9 +345,9 @@ file sealed class SharedFileObserver : IDisposable
     /// propagating the error to observers.
     /// </summary>
     /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The error event data.</param>
-    private void OnError(object sender, ErrorEventArgs e)
-        => OnError(e.GetException());
+    /// <param name="error">The error that occurred.</param>
+    private void OnError(object sender, Exception error)
+        => OnError(error);
 
     /// <summary>
     /// Propagates an error to all observers.
@@ -355,10 +355,10 @@ file sealed class SharedFileObserver : IDisposable
     /// <param name="error">The exception representing the error.</param>
     private void OnError(Exception error)
     {
-        IEnumerable<WeakReference<IObserver<FileSystemEventArgs>>> weakObservers = _observers.Values.SelectMany(static x => x);
-        foreach (WeakReference<IObserver<FileSystemEventArgs>> weakObserver in weakObservers)
+        IEnumerable<WeakReference<IObserver<FileChangeEventArgs>>> weakObservers = _observers.Values.SelectMany(static x => x);
+        foreach (WeakReference<IObserver<FileChangeEventArgs>> weakObserver in weakObservers)
         {
-            if (!weakObserver.TryGetTarget(out IObserver<FileSystemEventArgs>? observer) || observer is null)
+            if (!weakObserver.TryGetTarget(out IObserver<FileChangeEventArgs>? observer) || observer is null)
                 continue;
 
             observer.OnError(error);
@@ -370,10 +370,10 @@ file sealed class SharedFileObserver : IDisposable
     /// </summary>
     private void OnCompleted()
     {
-        IEnumerable<WeakReference<IObserver<FileSystemEventArgs>>> weakObservers = _observers.Values.SelectMany(static x => x);
-        foreach (WeakReference<IObserver<FileSystemEventArgs>> weakObserver in weakObservers)
+        IEnumerable<WeakReference<IObserver<FileChangeEventArgs>>> weakObservers = _observers.Values.SelectMany(static x => x);
+        foreach (WeakReference<IObserver<FileChangeEventArgs>> weakObserver in weakObservers)
         {
-            if (!weakObserver.TryGetTarget(out IObserver<FileSystemEventArgs>? observer) || observer is null)
+            if (!weakObserver.TryGetTarget(out IObserver<FileChangeEventArgs>? observer) || observer is null)
                 continue;
 
             observer.OnCompleted();

--- a/src/HotAvalonia.Core/IO/FileSystem.cs
+++ b/src/HotAvalonia.Core/IO/FileSystem.cs
@@ -152,124 +152,36 @@ public static class FileSystem
     }
 
     /// <summary>
-    /// A factory function used to instantiate <see cref="FileSystemEventArgs"/> objects.
-    /// </summary>
-    private static readonly Func<WatcherChangeTypes, string, string, FileSystemEventArgs> s_fileSystemEventArgsFactory = CreateFileSystemEventArgsFactory();
-
-    /// <summary>
-    /// Creates a new instance of the <see cref="FileSystemEventArgs"/> class.
+    /// Creates a new instance of the <see cref="FileChangeEventArgs"/> class.
     /// </summary>
     /// <param name="fileSystem">The file system associated with the event.</param>
     /// <param name="changeType">One of the <see cref="WatcherChangeTypes"/> values, which represents the kind of change detected in the file system.</param>
     /// <param name="fullPath">The fully qualified path of the affected file or directory.</param>
-    /// <returns>A new <see cref="FileSystemEventArgs"/> instance for the specified file system event.</returns>
-    public static FileSystemEventArgs CreateFileSystemEventArgs(this IFileSystem fileSystem, WatcherChangeTypes changeType, string fullPath)
+    /// <returns>A new <see cref="FileChangeEventArgs"/> instance for the specified file system event.</returns>
+    public static FileChangeEventArgs CreateFileChangeEventArgs(this IFileSystem fileSystem, WatcherChangeTypes changeType, string fullPath)
     {
         ArgumentNullException.ThrowIfNull(fileSystem);
         ArgumentNullException.ThrowIfNull(fullPath);
 
-        string name = fileSystem.GetFileName(fullPath);
-        return s_fileSystemEventArgsFactory(changeType, name, fullPath);
+        // HotAvalonia's own event type — the BCL FileSystemEventArgs is a throw-stub on iOS (ctor + FullPath
+        // getter both throw PlatformNotSupportedException), so it cannot be used in the watcher chain.
+        return new FileChangeEventArgs(changeType, fullPath);
     }
 
     /// <summary>
-    /// Creates a factory function used to instantiate <see cref="FileSystemEventArgs"/> objects.
-    /// </summary>
-    /// <returns>A factory function that creates <see cref="FileSystemEventArgs"/> objects.</returns>
-    private static Func<WatcherChangeTypes, string, string, FileSystemEventArgs> CreateFileSystemEventArgsFactory()
-    {
-        // public static FileSystemEventArgs CreateFileSystemEventArgs(WatcherChangeTypes changeType, string name, string fullPath)
-        // {
-        //     FileSystemEventArgs args = new(changeType, Path.DirectorySeparatorChar.ToString(), name);
-        //     args._fullPath = fullPath;
-        //     return args;
-        // }
-        Type returnType = typeof(FileSystemEventArgs);
-        Type[] parameterTypes = [typeof(WatcherChangeTypes), typeof(string), typeof(string)];
-
-        ConstructorInfo ctor = returnType.GetInstanceConstructor(parameterTypes)!;
-        FieldInfo fullPathField = returnType.GetInstanceField("_fullPath") ?? returnType.GetInstanceField("fullPath")!;
-
-        using IDisposable context = MethodHelper.DefineDynamicMethod("CreateFileSystemEventArgs", returnType, parameterTypes, out DynamicMethod method);
-
-        ILGenerator il = method.GetILGenerator();
-        il.Emit(OpCodes.Ldarg_0);
-#pragma warning disable RS0030 // Do not use banned APIs
-        il.Emit(OpCodes.Ldstr, Path.DirectorySeparatorChar.ToString());
-#pragma warning restore RS0030 // Do not use banned APIs
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Newobj, ctor);
-        il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Ldarg_2);
-        il.Emit(OpCodes.Stfld, fullPathField);
-        il.Emit(OpCodes.Ret);
-
-        return (Func<WatcherChangeTypes, string, string, FileSystemEventArgs>)method.CreateDelegate(typeof(Func<WatcherChangeTypes, string, string, FileSystemEventArgs>));
-    }
-
-    /// <summary>
-    /// A factory function used to instantiate <see cref="RenamedEventArgs"/> objects.
-    /// </summary>
-    private static readonly Func<WatcherChangeTypes, string, string, string, string, RenamedEventArgs> s_renamedEventArgsFactory = CreateRenamedEventArgsFactory();
-
-    /// <summary>
-    /// Creates a new instance of the <see cref="RenamedEventArgs"/> class.
+    /// Creates a new instance of the <see cref="FileRenameEventArgs"/> class.
     /// </summary>
     /// <param name="fileSystem">The file system associated with the event.</param>
     /// <param name="changeType">One of the <see cref="WatcherChangeTypes"/> values, which represents the kind of change detected in the file system.</param>
     /// <param name="fullPath">The fully qualified path of the affected file or directory.</param>
     /// <param name="oldFullPath">The previous fully qualified path of the affected file or directory.</param>
-    /// <returns>A new <see cref="RenamedEventArgs"/> instance for the specified file system event.</returns>
-    public static RenamedEventArgs CreateFileSystemEventArgs(this IFileSystem fileSystem, WatcherChangeTypes changeType, string fullPath, string oldFullPath)
+    /// <returns>A new <see cref="FileRenameEventArgs"/> instance for the specified file system event.</returns>
+    public static FileRenameEventArgs CreateFileChangeEventArgs(this IFileSystem fileSystem, WatcherChangeTypes changeType, string fullPath, string oldFullPath)
     {
         ArgumentNullException.ThrowIfNull(fileSystem);
         ArgumentNullException.ThrowIfNull(fullPath);
 
-        string name = fileSystem.GetFileName(fullPath);
-        string oldName = fileSystem.GetFileName(oldFullPath);
-        return s_renamedEventArgsFactory(changeType, name, fullPath, oldName, oldFullPath);
-    }
-
-    /// <summary>
-    /// Creates a factory function used to instantiate <see cref="RenamedEventArgs"/> objects.
-    /// </summary>
-    /// <returns>A factory function that creates <see cref="RenamedEventArgs"/> objects.</returns>
-    private static Func<WatcherChangeTypes, string, string, string, string, RenamedEventArgs> CreateRenamedEventArgsFactory()
-    {
-        // public static RenamedEventArgs CreateRenamedEventArgs(WatcherChangeTypes changeType, string name, string fullPath, string oldName, string oldFullPath)
-        // {
-        //     RenamedEventArgs args = new(changeType, Path.DirectorySeparatorChar.ToString(), name, oldName);
-        //     args._fullPath = fullPath;
-        //     args._oldFullPath = oldFullPath;
-        //     return args;
-        // }
-        Type parentType = typeof(FileSystemEventArgs);
-        Type returnType = typeof(RenamedEventArgs);
-        Type[] parameterTypes = [typeof(WatcherChangeTypes), typeof(string), typeof(string), typeof(string), typeof(string)];
-
-        ConstructorInfo ctor = returnType.GetInstanceConstructor([typeof(WatcherChangeTypes), typeof(string), typeof(string), typeof(string)])!;
-        FieldInfo fullPathField = parentType.GetInstanceField("_fullPath") ?? parentType.GetInstanceField("fullPath")!;
-        FieldInfo oldFullPathField = returnType.GetInstanceField("_oldFullPath") ?? returnType.GetInstanceField("oldFullPath")!;
-
-        using IDisposable context = MethodHelper.DefineDynamicMethod("CreateRenamedEventArgs", returnType, parameterTypes, out DynamicMethod method);
-
-        ILGenerator il = method.GetILGenerator();
-        il.Emit(OpCodes.Ldarg_0);
-#pragma warning disable RS0030 // Do not use banned APIs
-        il.Emit(OpCodes.Ldstr, Path.DirectorySeparatorChar.ToString());
-#pragma warning restore RS0030 // Do not use banned APIs
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Ldarg_3);
-        il.Emit(OpCodes.Newobj, ctor);
-        il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Ldarg_2);
-        il.Emit(OpCodes.Stfld, fullPathField);
-        il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Ldarg_S, 4);
-        il.Emit(OpCodes.Stfld, oldFullPathField);
-        il.Emit(OpCodes.Ret);
-
-        return (Func<WatcherChangeTypes, string, string, string, string, RenamedEventArgs>)method.CreateDelegate(typeof(Func<WatcherChangeTypes, string, string, string, string, RenamedEventArgs>));
+        return new FileRenameEventArgs(changeType, fullPath, oldFullPath);
     }
 
     /// <summary>

--- a/src/HotAvalonia.Core/IO/FileWatcher.cs
+++ b/src/HotAvalonia.Core/IO/FileWatcher.cs
@@ -15,7 +15,7 @@ internal sealed class FileWatcher : IDisposable
     /// <summary>
     /// The cache of filesystem events.
     /// </summary>
-    private readonly MemoryCache<FileSystemEventArgs> _eventCache;
+    private readonly MemoryCache<FileChangeEventArgs> _eventCache;
 
     /// <summary>
     /// The object used for locking in thread-safe operations.
@@ -78,17 +78,17 @@ internal sealed class FileWatcher : IDisposable
     /// <summary>
     /// Occurs when a change in a file is detected.
     /// </summary>
-    public event FileSystemEventHandler? Changed;
+    public event FileChangeEventHandler? Changed;
 
     /// <summary>
     /// Occurs when a move operation for a file is detected.
     /// </summary>
-    public event RenamedEventHandler? Renamed;
+    public event FileRenameEventHandler? Renamed;
 
     /// <summary>
     /// Occurs when an error is encountered during file monitoring.
     /// </summary>
-    public event ErrorEventHandler? Error;
+    public event FileWatcherErrorEventHandler? Error;
 
     /// <summary>
     /// The root directory being watched.
@@ -146,7 +146,7 @@ internal sealed class FileWatcher : IDisposable
     /// </summary>
     /// <param name="sender">The source of the event.</param>
     /// <param name="args">The event arguments containing information about the file change.</param>
-    private void OnCreatedOrDeleted(object sender, FileSystemEventArgs args)
+    private void OnCreatedOrDeleted(object sender, FileChangeEventArgs args)
         => OnFileSystemEvent(args);
 
     /// <summary>
@@ -154,7 +154,7 @@ internal sealed class FileWatcher : IDisposable
     /// </summary>
     /// <param name="sender">The source of the event.</param>
     /// <param name="args">The event arguments containing information about the file change.</param>
-    private void OnChanged(object sender, FileSystemEventArgs args)
+    private void OnChanged(object sender, FileChangeEventArgs args)
         => OnFileSystemEvent(args, () => Changed?.Invoke(this, args));
 
     /// <summary>
@@ -162,7 +162,7 @@ internal sealed class FileWatcher : IDisposable
     /// </summary>
     /// <param name="sender">The source of the event.</param>
     /// <param name="args">Event arguments containing the old and new name of the file.</param>
-    private void OnRenamed(object sender, RenamedEventArgs args)
+    private void OnRenamed(object sender, FileRenameEventArgs args)
         => OnFileSystemEvent(args, () => Renamed?.Invoke(this, args), () =>
         {
             _files.Remove(args.OldFullPath);
@@ -173,9 +173,9 @@ internal sealed class FileWatcher : IDisposable
     /// Handles any error that occurs during file watching.
     /// </summary>
     /// <param name="sender">The source of the event.</param>
-    /// <param name="args">The event arguments containing error details.</param>
-    private void OnError(object sender, ErrorEventArgs args)
-        => Error?.Invoke(this, args);
+    /// <param name="error">The error that occurred.</param>
+    private void OnError(object sender, Exception error)
+        => Error?.Invoke(this, error);
 
     /// <summary>
     /// Handles a filesystem event, performing necessary actions based on the event type.
@@ -184,12 +184,12 @@ internal sealed class FileWatcher : IDisposable
     /// <param name="path">The path of the file associated with the event.</param>
     /// <param name="handler">A handler for the event.</param>
     /// <param name="sync">An action to synchronize changes after processing the event.</param>
-    private void OnFileSystemEvent(FileSystemEventArgs args, Action? handler = null, Action? sync = null)
+    private void OnFileSystemEvent(FileChangeEventArgs args, Action? handler = null, Action? sync = null)
     {
         lock (_lock)
         {
             bool isFullPathWatched = IsWatchingFile(args.FullPath);
-            bool isOldFullPathWatched = args is RenamedEventArgs renamed && IsWatchingFile(renamed.OldFullPath);
+            bool isOldFullPathWatched = args is FileRenameEventArgs renamed && IsWatchingFile(renamed.OldFullPath);
             if (!isFullPathWatched && !isOldFullPathWatched)
             {
                 _eventCache.Add(args);
@@ -223,7 +223,7 @@ internal sealed class FileWatcher : IDisposable
     /// </summary>
     /// <param name="args">The event arguments containing information about the filesystem operation.</param>
     /// <returns><c>true</c> if the event is a duplicate; otherwise, <c>false</c>.</returns>
-    private bool IsDuplicateEvent(FileSystemEventArgs args)
+    private bool IsDuplicateEvent(FileChangeEventArgs args)
     {
         // Currently, we only care about filtering duplicate change events:
         // - They trigger most of the unnecessary work.
@@ -247,7 +247,7 @@ internal sealed class FileWatcher : IDisposable
     /// </summary>
     /// <param name="args">The event arguments containing information about the filesystem operation.</param>
     /// <returns><c>true</c> if a complex event (change or move operation) was successfully processed; otherwise, <c>false</c>.</returns>
-    private bool TryProcessComplexEvent(FileSystemEventArgs args)
+    private bool TryProcessComplexEvent(FileChangeEventArgs args)
         => TryProcessComplexChange_NTFS(args)
         || TryProcessComplexChange_ReFS(args)
         || TryProcessComplexMove(args);
@@ -270,7 +270,7 @@ internal sealed class FileWatcher : IDisposable
     /// </remarks>
     /// <param name="args">The event arguments containing information about the filesystem operation.</param>
     /// <returns><c>true</c> if a complex move operation was successfully processed; otherwise, <c>false</c>.</returns>
-    private bool TryProcessComplexMove(FileSystemEventArgs args)
+    private bool TryProcessComplexMove(FileChangeEventArgs args)
     {
         if (args.ChangeType is not (WatcherChangeTypes.Created or WatcherChangeTypes.Deleted))
             return false;
@@ -283,7 +283,7 @@ internal sealed class FileWatcher : IDisposable
 
         lock (_lock)
         {
-            FileSystemEventArgs? oppositeEvent = _eventCache.FirstOrDefault(x => x.ChangeType == oppositeChangeType && fileNameComparer.Equals(x.FullPath, fileName));
+            FileChangeEventArgs? oppositeEvent = _eventCache.FirstOrDefault(x => x.ChangeType == oppositeChangeType && fileNameComparer.Equals(x.FullPath, fileName));
             if (oppositeEvent is null)
                 return false;
 
@@ -292,7 +292,7 @@ internal sealed class FileWatcher : IDisposable
                 : (oppositeEvent.FullPath, args.FullPath);
         }
 
-        OnRenamed(this, _fileSystem.CreateFileSystemEventArgs(WatcherChangeTypes.Renamed, newFullPath, oldFullPath));
+        OnRenamed(this, _fileSystem.CreateFileChangeEventArgs(WatcherChangeTypes.Renamed, newFullPath, oldFullPath));
         return true;
     }
 
@@ -322,7 +322,7 @@ internal sealed class FileWatcher : IDisposable
     /// </remarks>
     /// <param name="args">The event arguments containing information about the filesystem operation.</param>
     /// <returns><c>true</c> if a complex change operation was successfully processed; otherwise, <c>false</c>.</returns>
-    private bool TryProcessComplexChange_NTFS(FileSystemEventArgs args)
+    private bool TryProcessComplexChange_NTFS(FileChangeEventArgs args)
     {
         if (args.ChangeType is not WatcherChangeTypes.Deleted)
             return false;
@@ -333,7 +333,7 @@ internal sealed class FileWatcher : IDisposable
         lock (_lock)
         {
             previousPath = _eventCache
-                .OfType<RenamedEventArgs>()
+                .OfType<FileRenameEventArgs>()
                 .FirstOrDefault(x => fileNameComparer.Equals(x.FullPath, path))?.OldFullPath;
         }
 
@@ -346,8 +346,8 @@ internal sealed class FileWatcher : IDisposable
             _files.Add(previousPath);
         }
 
-        Renamed?.Invoke(this, _fileSystem.CreateFileSystemEventArgs(WatcherChangeTypes.Renamed, previousPath, path));
-        Changed?.Invoke(this, _fileSystem.CreateFileSystemEventArgs(WatcherChangeTypes.Changed, previousPath));
+        Renamed?.Invoke(this, _fileSystem.CreateFileChangeEventArgs(WatcherChangeTypes.Renamed, previousPath, path));
+        Changed?.Invoke(this, _fileSystem.CreateFileChangeEventArgs(WatcherChangeTypes.Changed, previousPath));
         return true;
     }
 
@@ -374,9 +374,9 @@ internal sealed class FileWatcher : IDisposable
     /// </remarks>
     /// <param name="args">The event arguments containing information about the filesystem operation.</param>
     /// <returns><c>true</c> if a complex change operation was successfully processed; otherwise, <c>false</c>.</returns>
-    private bool TryProcessComplexChange_ReFS(FileSystemEventArgs args)
+    private bool TryProcessComplexChange_ReFS(FileChangeEventArgs args)
     {
-        if (args is not RenamedEventArgs renamedArgs)
+        if (args is not FileRenameEventArgs renamedArgs)
             return false;
 
         // We only want to catch an event when an untracked file
@@ -399,7 +399,7 @@ internal sealed class FileWatcher : IDisposable
 
         // `FileWatcher` currently does not propagate `Deleted` events to its subscribers.
         // However, if this ever changes, we will need to create a synthetic `Created` event here as well.
-        Changed?.Invoke(this, _fileSystem.CreateFileSystemEventArgs(WatcherChangeTypes.Changed, path));
+        Changed?.Invoke(this, _fileSystem.CreateFileChangeEventArgs(WatcherChangeTypes.Changed, path));
         return true;
     }
 

--- a/src/HotAvalonia.Core/IO/IFileSystemWatcher.cs
+++ b/src/HotAvalonia.Core/IO/IFileSystemWatcher.cs
@@ -41,25 +41,25 @@ public interface IFileSystemWatcher : IDisposable
     /// <summary>
     /// Occurs when a file or directory in the specified <see cref="Path"/> is created.
     /// </summary>
-    event FileSystemEventHandler Created;
+    event FileChangeEventHandler Created;
 
     /// <summary>
     /// Occurs when a file or directory in the specified <see cref="Path"/> is deleted.
     /// </summary>
-    event FileSystemEventHandler Deleted;
+    event FileChangeEventHandler Deleted;
 
     /// <summary>
     /// Occurs when a file or directory in the specified <see cref="Path"/> is changed.
     /// </summary>
-    event FileSystemEventHandler Changed;
+    event FileChangeEventHandler Changed;
 
     /// <summary>
     /// Occurs when a file or directory in the specified <see cref="Path"/> is renamed.
     /// </summary>
-    event RenamedEventHandler Renamed;
+    event FileRenameEventHandler Renamed;
 
     /// <summary>
     /// Occurs when this instance is unable to continue monitoring changes.
     /// </summary>
-    event ErrorEventHandler Error;
+    event FileWatcherErrorEventHandler Error;
 }

--- a/src/HotAvalonia.Core/IO/LocalFileSystemWatcher.cs
+++ b/src/HotAvalonia.Core/IO/LocalFileSystemWatcher.cs
@@ -9,9 +9,44 @@ internal sealed class LocalFileSystemWatcher : FileSystemWatcher, IFileSystemWat
     /// <inheritdoc/>
     public IFileSystem FileSystem { get; }
 
+    private FileChangeEventHandler? _created;
+    private FileChangeEventHandler? _deleted;
+    private FileChangeEventHandler? _changed;
+    private FileRenameEventHandler? _renamed;
+    private FileWatcherErrorEventHandler? _error;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="LocalFileSystemWatcher"/> class.
     /// </summary>
     /// <param name="fileSystem">The file system associated with this system.</param>
-    public LocalFileSystemWatcher(LocalFileSystem fileSystem) => FileSystem = fileSystem;
+    public LocalFileSystemWatcher(LocalFileSystem fileSystem)
+    {
+        FileSystem = fileSystem;
+
+        // Translate the BCL FileSystemWatcher events into HotAvalonia's platform-safe event types. This
+        // class is only instantiated on desktop, where the base FileSystemWatcher is real; iOS uses
+        // RemoteFileSystemWatcher and never constructs this type.
+#pragma warning disable RS0030 // Do not use banned APIs — the base BCL FileSystemWatcher is the desktop source of events.
+        base.Created += (_, e) => _created?.Invoke(this, new FileChangeEventArgs(e.ChangeType, e.FullPath));
+        base.Deleted += (_, e) => _deleted?.Invoke(this, new FileChangeEventArgs(e.ChangeType, e.FullPath));
+        base.Changed += (_, e) => _changed?.Invoke(this, new FileChangeEventArgs(e.ChangeType, e.FullPath));
+        base.Renamed += (_, e) => _renamed?.Invoke(this, new FileRenameEventArgs(e.ChangeType, e.FullPath, e.OldFullPath));
+        base.Error += (_, e) => _error?.Invoke(this, e.GetException());
+#pragma warning restore RS0030
+    }
+
+    /// <inheritdoc/>
+    event FileChangeEventHandler IFileSystemWatcher.Created { add => _created += value; remove => _created -= value; }
+
+    /// <inheritdoc/>
+    event FileChangeEventHandler IFileSystemWatcher.Deleted { add => _deleted += value; remove => _deleted -= value; }
+
+    /// <inheritdoc/>
+    event FileChangeEventHandler IFileSystemWatcher.Changed { add => _changed += value; remove => _changed -= value; }
+
+    /// <inheritdoc/>
+    event FileRenameEventHandler IFileSystemWatcher.Renamed { add => _renamed += value; remove => _renamed -= value; }
+
+    /// <inheritdoc/>
+    event FileWatcherErrorEventHandler IFileSystemWatcher.Error { add => _error += value; remove => _error -= value; }
 }

--- a/src/HotAvalonia.Core/IO/RemoteFileSystemWatcher.cs
+++ b/src/HotAvalonia.Core/IO/RemoteFileSystemWatcher.cs
@@ -153,19 +153,19 @@ internal sealed partial class RemoteFileSystemWatcher : IFileSystemWatcher
     }
 
     /// <inheritdoc/>
-    public event FileSystemEventHandler? Created;
+    public event FileChangeEventHandler? Created;
 
     /// <inheritdoc/>
-    public event FileSystemEventHandler? Deleted;
+    public event FileChangeEventHandler? Deleted;
 
     /// <inheritdoc/>
-    public event FileSystemEventHandler? Changed;
+    public event FileChangeEventHandler? Changed;
 
     /// <inheritdoc/>
-    public event RenamedEventHandler? Renamed;
+    public event FileRenameEventHandler? Renamed;
 
     /// <inheritdoc/>
-    public event ErrorEventHandler? Error;
+    public event FileWatcherErrorEventHandler? Error;
 
     /// <summary>
     /// Sets a field to a new value and sends a packet to the remote file system if the value changes.
@@ -243,7 +243,7 @@ internal sealed partial class RemoteFileSystemWatcher : IFileSystemWatcher
             }
             catch (Exception e)
             {
-                Error?.Invoke(this, new(e));
+                Error?.Invoke(this, e);
                 break;
             }
 
@@ -281,21 +281,21 @@ internal sealed partial class RemoteFileSystemWatcher : IFileSystemWatcher
                 break;
 
             case ActionType.RaiseRenamed:
-                Renamed?.Invoke(this, (RenamedEventArgs)ToFileSystemEventArgs(data));
+                Renamed?.Invoke(this, (FileRenameEventArgs)ToFileSystemEventArgs(data));
                 break;
 
             case ActionType.RaiseError:
-                Error?.Invoke(this, new(RemoteFileSystemException.ToException(data)));
+                Error?.Invoke(this, RemoteFileSystemException.ToException(data));
                 break;
         }
     }
 
     /// <summary>
-    /// Converts serialized event data represented as a byte array back to a <see cref="FileSystemEventArgs"/> instance.
+    /// Converts serialized event data represented as a byte array back to a <see cref="FileChangeEventArgs"/> instance.
     /// </summary>
     /// <param name="data">The byte array representing the serialized event data.</param>
-    /// <returns>A <see cref="FileSystemEventArgs"/> instance based on the byte array content.</returns>
-    private FileSystemEventArgs ToFileSystemEventArgs(byte[] data)
+    /// <returns>A <see cref="FileChangeEventArgs"/> instance based on the byte array content.</returns>
+    private FileChangeEventArgs ToFileSystemEventArgs(byte[] data)
     {
         int fullPathByteCount = BitConverter.ToInt32(data.AsSpan(sizeof(byte), sizeof(int)));
         int mainByteCount = sizeof(byte) + sizeof(int) + fullPathByteCount;
@@ -304,10 +304,10 @@ internal sealed partial class RemoteFileSystemWatcher : IFileSystemWatcher
         WatcherChangeTypes changeType = (WatcherChangeTypes)data[0];
         string fullPath = Encoding.UTF8.GetString(data, sizeof(byte) + sizeof(int), fullPathByteCount);
         if (oldFullPathByteCount <= 0)
-            return _fileSystem.CreateFileSystemEventArgs(changeType, fullPath);
+            return _fileSystem.CreateFileChangeEventArgs(changeType, fullPath);
 
         string oldFullPath = Encoding.UTF8.GetString(data, mainByteCount, oldFullPathByteCount);
-        return _fileSystem.CreateFileSystemEventArgs(changeType, fullPath, oldFullPath);
+        return _fileSystem.CreateFileChangeEventArgs(changeType, fullPath, oldFullPath);
     }
 
     /// <inheritdoc/>

--- a/src/HotAvalonia.Core/Xaml/HostCompiledXamlLoader.cs
+++ b/src/HotAvalonia.Core/Xaml/HostCompiledXamlLoader.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+
+namespace HotAvalonia.Xaml;
+
+/// <summary>
+/// Extracts the build and populate methods from a host-compiled XAML assembly.
+/// </summary>
+/// <remarks>
+/// iOS forbids runtime <c>Reflection.Emit</c>, so the on-device <see cref="XamlCompiler"/> path is a
+/// dead end there. Instead the Mac compiles a single changed view into a standalone "populate DLL"
+/// (a host-side build step) using Avalonia's exact build-time XAML compiler, with
+/// <c>x:Class</c> stripped so the generated resource methods bind the REFERENCED (device) root type:
+///   <c>CompiledAvaloniaXaml.!AvaloniaResources::Build:&lt;uri&gt;(IServiceProvider) -&gt; TRoot</c>
+///   <c>CompiledAvaloniaXaml.!AvaloniaResources::Populate:&lt;uri&gt;(IServiceProvider, TRoot)</c>
+/// This loader finds that pair by root type (one view per DLL), so the device can drive its existing
+/// emit-free <c>!XamlIlPopulateOverride</c> reload path with a Mac-compiled tree.
+/// </remarks>
+internal static class HostCompiledXamlLoader
+{
+    /// <summary>
+    /// Determines whether the given assembly is a host-compiled populate carrier.
+    /// </summary>
+    /// <param name="assembly">The assembly to check.</param>
+    /// <returns><c>true</c> if the assembly was produced by the host compiler; otherwise, <c>false</c>.</returns>
+    public static bool IsHostCompiledAssembly(Assembly assembly)
+        => assembly.GetName().Name?.StartsWith(HostCompiledXamlNaming.AssemblyNamePrefix, StringComparison.Ordinal) == true;
+
+
+    /// <summary>
+    /// Finds the build/populate pair in a host-compiled assembly that targets the given root type.
+    /// </summary>
+    /// <param name="assembly">The host-compiled (populate) assembly.</param>
+    /// <param name="rootType">The root control type the methods must target (the live device type).</param>
+    /// <param name="build">When this method returns, the build method, if found.</param>
+    /// <param name="populate">When this method returns, the populate method, if found.</param>
+    /// <returns><c>true</c> if a matching pair was found; otherwise, <c>false</c>.</returns>
+    public static bool TryFindResourceMethods(Assembly assembly, Type rootType, out MethodBase build, out MethodInfo populate)
+    {
+        build = null!;
+        populate = null!;
+
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+        foreach (Type type in GetTypesSafe(assembly))
+        {
+            foreach (MethodInfo method in type.GetMethods(flags))
+            {
+                string name = method.Name;
+                if (populate is null && name.StartsWith("Populate:", StringComparison.Ordinal) && XamlScanner.IsPopulateMethod(method))
+                {
+                    ParameterInfo[] parameters = method.GetParameters();
+                    if (parameters.Length == 2 && parameters[1].ParameterType.IsAssignableFrom(rootType))
+                        populate = method;
+                }
+                else if (build is null && name.StartsWith("Build:", StringComparison.Ordinal) && XamlScanner.IsBuildMethod(method)
+                         && method is MethodInfo { ReturnType: Type returnType } && rootType.IsAssignableFrom(returnType))
+                {
+                    build = method;
+                }
+
+                if (build is not null && populate is not null)
+                    return true;
+            }
+        }
+
+        return build is not null && populate is not null;
+    }
+
+    private static IEnumerable<Type> GetTypesSafe(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException e)
+        {
+            return e.Types.Where(static t => t is not null)!;
+        }
+    }
+}

--- a/src/HotAvalonia.Core/Xaml/HostCompiledXamlNaming.cs
+++ b/src/HotAvalonia.Core/Xaml/HostCompiledXamlNaming.cs
@@ -1,0 +1,22 @@
+namespace HotAvalonia.Xaml;
+
+/// <summary>
+/// The naming contract shared between the device-side host-compiled XAML loader and the host-side
+/// compiler that produces the populate DLLs. Both sides must agree on these values, so they live in
+/// one place (this file is linked into the host compiler tool).
+/// </summary>
+internal static class HostCompiledXamlNaming
+{
+    /// <summary>
+    /// The assembly-name prefix the host compiler must use when naming each populate DLL.
+    /// The <see cref="System.AssemblyLoadEventArgs"/> hook skips these so a transient populate DLL is
+    /// never mistaken for a new project to watch (which also avoids a native Mono load-hook assertion on iOS).
+    /// </summary>
+    public const string AssemblyNamePrefix = "HotAvaloniaHostCompiled_";
+
+    /// <summary>
+    /// The suffix appended to a view's <c>.axaml</c> path to locate its host-compiled sidecar DLL
+    /// (e.g. <c>MyView.axaml</c> -&gt; <c>MyView.axaml.hotreload.dll</c>).
+    /// </summary>
+    public const string SidecarSuffix = ".hotreload.dll";
+}

--- a/src/HotAvalonia.Core/Xaml/XamlScanner.cs
+++ b/src/HotAvalonia.Core/Xaml/XamlScanner.cs
@@ -178,10 +178,15 @@ public static class XamlScanner
         Type? xamlLoader = assembly.GetType("CompiledAvaloniaXaml.!XamlLoader");
         MethodInfo? tryLoad = xamlLoader?.GetStaticMethods("TryLoad").OrderByDescending(x => x.GetParameters().Length).FirstOrDefault();
         byte[]? tryLoadBody = tryLoad?.GetMethodBody()?.GetILAsByteArray();
-        if (tryLoad is null || tryLoadBody is null)
-            return [];
 
-        IEnumerable<CompiledXamlDocument> extractedDocuments = ExtractDocuments(tryLoadBody, tryLoad.Module);
+        // The iOS Full linker can trim CompiledAvaloniaXaml.!XamlLoader from assemblies whose views are
+        // populated directly (e.g. an app's views assembly), leaving the per-view !XamlIlPopulate methods
+        // intact. Don't bail when TryLoad is absent — fall through to the type-scan (FindDocuments) path,
+        // which discovers those views. Bailing here was why iOS hot reload found 0 documents for the
+        // views assembly and never created a watcher.
+        IEnumerable<CompiledXamlDocument> extractedDocuments = tryLoad is null || tryLoadBody is null
+            ? []
+            : ExtractDocuments(tryLoadBody, tryLoad.Module);
         IEnumerable<CompiledXamlDocument> foundDocuments = FindDocuments(assembly);
         return extractedDocuments.Concat(foundDocuments).Distinct();
     }

--- a/src/HotAvalonia.HostCompiler/AssemblyClosure.cs
+++ b/src/HotAvalonia.HostCompiler/AssemblyClosure.cs
@@ -1,0 +1,107 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text.RegularExpressions;
+
+namespace HotAvalonia.HostCompiler;
+
+/// <summary>
+/// Indexes a set of reference assemblies (the "closure" of the target app's pre-link build output) so the
+/// compiler can resolve which assembly defines a given XAML <c>clr-namespace</c> and enumerate the
+/// assemblies that need <c>IgnoresAccessChecksTo</c>. Uses <see cref="MetadataReader"/> only, so it is
+/// fully cross-platform (no Mono/<c>monodis</c>).
+/// </summary>
+internal sealed class AssemblyClosure
+{
+    private readonly Dictionary<string, string> _namespaceToAssembly;
+    private readonly List<string> _assemblyNames;
+
+    private AssemblyClosure(Dictionary<string, string> namespaceToAssembly, List<string> assemblyNames)
+    {
+        _namespaceToAssembly = namespaceToAssembly;
+        _assemblyNames = assemblyNames;
+    }
+
+    /// <summary>
+    /// The simple names of every referenced (non-excluded) assembly in the closure.
+    /// </summary>
+    public IReadOnlyList<string> AssemblyNames => _assemblyNames;
+
+    /// <summary>
+    /// Resolves the assembly that defines types in the given CLR namespace.
+    /// </summary>
+    public bool TryGetAssemblyForNamespace(string clrNamespace, out string assemblyName)
+        => _namespaceToAssembly.TryGetValue(clrNamespace, out assemblyName!);
+
+    /// <summary>
+    /// Scans every managed DLL under <paramref name="closureDirectory"/> (skipping files whose name matches
+    /// an entry in <paramref name="excludePatterns"/>) and builds the namespace/assembly indexes.
+    /// </summary>
+    public static AssemblyClosure Load(string closureDirectory, IReadOnlyList<string> excludePatterns)
+    {
+        Regex[] excludes = [.. excludePatterns.Select(ToFileNameRegex)];
+        Dictionary<string, string> namespaceToAssembly = new(StringComparer.Ordinal);
+        List<string> assemblyNames = [];
+
+        foreach (string dllPath in Directory.EnumerateFiles(closureDirectory, "*.dll"))
+        {
+            string fileName = Path.GetFileName(dllPath);
+            if (excludes.Any(rx => rx.IsMatch(fileName)))
+                continue;
+
+            string? assemblyName = TryIndexAssembly(dllPath, namespaceToAssembly);
+            if (assemblyName is not null)
+                assemblyNames.Add(assemblyName);
+        }
+
+        return new AssemblyClosure(namespaceToAssembly, assemblyNames);
+    }
+
+    private static string? TryIndexAssembly(string dllPath, Dictionary<string, string> namespaceToAssembly)
+    {
+        try
+        {
+            using FileStream stream = File.OpenRead(dllPath);
+            using PEReader peReader = new(stream);
+            if (!peReader.HasMetadata)
+                return null;
+
+            MetadataReader reader = peReader.GetMetadataReader();
+            if (!reader.IsAssembly)
+                return null;
+
+            string assemblyName = reader.GetString(reader.GetAssemblyDefinition().Name);
+
+            foreach (TypeDefinitionHandle handle in reader.TypeDefinitions)
+            {
+                TypeDefinition type = reader.GetTypeDefinition(handle);
+
+                // Only top-level types carry a namespace worth indexing; nested types have a declaring type.
+                if (!type.GetDeclaringType().IsNil)
+                    continue;
+
+                if (type.Namespace.IsNil)
+                    continue;
+
+                string ns = reader.GetString(type.Namespace);
+                if (ns.Length == 0)
+                    continue;
+
+                // First assembly that defines the namespace wins (matches the original single-assembly recipe).
+                namespaceToAssembly.TryAdd(ns, assemblyName);
+            }
+
+            return assemblyName;
+        }
+        catch (BadImageFormatException)
+        {
+            // Native or otherwise unreadable image - not part of the managed closure.
+            return null;
+        }
+    }
+
+    private static Regex ToFileNameRegex(string pattern)
+    {
+        string regex = "^" + Regex.Escape(pattern).Replace("\\*", ".*", StringComparison.Ordinal) + "$";
+        return new Regex(regex, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+}

--- a/src/HotAvalonia.HostCompiler/AxamlTransform.cs
+++ b/src/HotAvalonia.HostCompiler/AxamlTransform.cs
@@ -1,0 +1,49 @@
+using System.Text.RegularExpressions;
+
+namespace HotAvalonia.HostCompiler;
+
+/// <summary>
+/// Rewrites a source <c>.axaml</c> into the classless form the host compiler builds: the <c>x:Class</c>
+/// attribute is removed, and every bare <c>clr-namespace:</c> xmlns that the closure can resolve gets an
+/// <c>;assembly=</c> qualifier so its types bind the REFERENCED (device) identities rather than the
+/// throwaway compiling assembly. The root element is left untouched (Avalonia views are rooted on their
+/// own type), so the generated populate binds that type.
+/// </summary>
+internal static partial class AxamlTransform
+{
+    /// <summary>
+    /// Transforms <paramref name="xaml"/> and reports the full <c>x:Class</c> type name (empty if none).
+    /// </summary>
+    public static string Transform(string xaml, AssemblyClosure closure, out string viewClassName)
+    {
+        // The XAML-language prefix is conventionally "x"; resolve it from the document, default to "x".
+        Match namespaceMatch = XamlNamespaceRegex().Match(xaml);
+        string xamlPrefix = namespaceMatch.Success ? namespaceMatch.Groups[1].Value : "x";
+
+        // Capture and strip "<prefix>:Class=...".
+        Regex classRegex = new(
+            $@"\s*{Regex.Escape(xamlPrefix)}:Class\s*=\s*""([^""]*)""",
+            RegexOptions.CultureInvariant);
+        Match classMatch = classRegex.Match(xaml);
+        viewClassName = classMatch.Success ? classMatch.Groups[1].Value : string.Empty;
+        string result = classRegex.Replace(xaml, string.Empty, 1);
+
+        // Append ";assembly=" to each bare clr-namespace xmlns the closure can resolve.
+        result = ClrNamespaceRegex().Replace(result, match =>
+        {
+            string clrNamespace = match.Groups[2].Value;
+            if (!closure.TryGetAssemblyForNamespace(clrNamespace, out string assembly))
+                return match.Value;
+
+            return $@"xmlns{match.Groups[1].Value}=""clr-namespace:{clrNamespace};assembly={assembly}""";
+        });
+
+        return result;
+    }
+
+    [GeneratedRegex(@"xmlns:(\w+)\s*=\s*""http://schemas\.microsoft\.com/winfx/2006/xaml""", RegexOptions.CultureInvariant)]
+    private static partial Regex XamlNamespaceRegex();
+
+    [GeneratedRegex(@"xmlns(:\w+)?\s*=\s*""clr-namespace:([^"";]+)""", RegexOptions.CultureInvariant)]
+    private static partial Regex ClrNamespaceRegex();
+}

--- a/src/HotAvalonia.HostCompiler/CompileContext.cs
+++ b/src/HotAvalonia.HostCompiler/CompileContext.cs
@@ -1,0 +1,11 @@
+namespace HotAvalonia.HostCompiler;
+
+/// <summary>
+/// The resolved, view-independent inputs for compiling views (shared across a one-shot compile and every
+/// iteration of a watch session).
+/// </summary>
+internal sealed record CompileContext(
+    string ClosureDirectory,
+    string AvaloniaVersion,
+    string TargetFramework,
+    IReadOnlyList<string> ExcludePatterns);

--- a/src/HotAvalonia.HostCompiler/HostXamlCompiler.cs
+++ b/src/HotAvalonia.HostCompiler/HostXamlCompiler.cs
@@ -1,0 +1,187 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using HotAvalonia.Xaml;
+
+namespace HotAvalonia.HostCompiler;
+
+/// <summary>
+/// Options controlling a single host-side XAML compile.
+/// </summary>
+internal sealed record HostCompileOptions
+{
+    /// <summary>The source <c>.axaml</c> file to compile.</summary>
+    public required string ViewPath { get; init; }
+
+    /// <summary>The pre-link build-output directory whose assemblies carry the device's exact identities.</summary>
+    public required string ClosureDirectory { get; init; }
+
+    /// <summary>The exact Avalonia package version the target app uses.</summary>
+    public required string AvaloniaVersion { get; init; }
+
+    /// <summary>The target framework of the throwaway compile project.</summary>
+    public string TargetFramework { get; init; } = "net10.0";
+
+    /// <summary>File-name glob patterns excluded from the reference closure (BCL + Avalonia).</summary>
+    public IReadOnlyList<string> ExcludePatterns { get; init; } = HostXamlCompiler.DefaultExcludePatterns;
+
+    /// <summary>The sidecar output path; defaults to <c>&lt;view&gt;.axaml.hotreload.dll</c> next to the source.</summary>
+    public string? OutputPath { get; init; }
+}
+
+/// <summary>
+/// Compiles one changed Avalonia view into a standalone "populate DLL" using Avalonia's exact build-time
+/// XAML compiler (via a throwaway project + <c>dotnet build</c>), so an AOT/iOS device can load and apply
+/// it without runtime <c>Reflection.Emit</c>.
+/// </summary>
+internal static class HostXamlCompiler
+{
+    /// <summary>BCL + Avalonia are excluded from the closure (the SDK and the Avalonia package supply them).</summary>
+    public static readonly IReadOnlyList<string> DefaultExcludePatterns =
+    [
+        "System.*.dll", "Microsoft.*.dll", "mscorlib.dll", "netstandard.dll", "Mono.*.dll", "Avalonia*.dll",
+    ];
+
+    /// <summary>
+    /// Compiles the view described by <paramref name="options"/> and returns the produced sidecar path.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The inputs are invalid or the compile failed.</exception>
+    public static string Compile(HostCompileOptions options)
+    {
+        if (!File.Exists(options.ViewPath))
+            throw new InvalidOperationException($"View not found: {options.ViewPath}");
+        if (!Directory.Exists(options.ClosureDirectory))
+            throw new InvalidOperationException($"Reference closure directory not found: {options.ClosureDirectory}");
+
+        AssemblyClosure closure = AssemblyClosure.Load(options.ClosureDirectory, options.ExcludePatterns);
+
+        string sourceXaml = File.ReadAllText(options.ViewPath);
+        string transformed = AxamlTransform.Transform(sourceXaml, closure, out string viewClassName);
+
+        string viewName = viewClassName.Length > 0
+            ? viewClassName[(viewClassName.LastIndexOf('.') + 1)..]
+            : Path.GetFileNameWithoutExtension(options.ViewPath);
+
+        // Unique identity per content so the device's repeated Assembly.Load calls never collide.
+        string hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(transformed)))[..8];
+        string assemblyName = $"{HostCompiledXamlNaming.AssemblyNamePrefix}{viewName}_{hash}";
+        string outputPath = options.OutputPath ?? options.ViewPath + HostCompiledXamlNaming.SidecarSuffix;
+
+        string projectDir = Directory.CreateTempSubdirectory("hotavalonia-hostcompile-").FullName;
+        try
+        {
+            string viewFileName = viewName + ".axaml";
+            Directory.CreateDirectory(Path.Combine(projectDir, "Views"));
+            File.WriteAllText(Path.Combine(projectDir, "Views", viewFileName), transformed);
+            File.WriteAllText(Path.Combine(projectDir, "IgnoresAccessChecks.cs"), BuildIgnoresAccessChecks(closure.AssemblyNames));
+
+            string projectPath = Path.Combine(projectDir, "HotReloadView.csproj");
+            File.WriteAllText(projectPath, BuildProject(options, assemblyName, viewFileName));
+
+            RunDotnetBuild(projectPath, projectDir);
+
+            string producedDll = Path.Combine(projectDir, "bin", "Debug", options.TargetFramework, assemblyName + ".dll");
+            if (!File.Exists(producedDll))
+                throw new InvalidOperationException($"Build succeeded but produced no DLL at {producedDll}.");
+
+            // Write-then-rename so a file server never serves a half-written DLL.
+            string tempOutput = $"{outputPath}.tmp.{Environment.ProcessId}";
+            File.Copy(producedDll, tempOutput, overwrite: true);
+            File.Move(tempOutput, outputPath, overwrite: true);
+            return outputPath;
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(projectDir, recursive: true);
+            }
+            catch (IOException)
+            {
+                // Best-effort cleanup of the throwaway project; a leftover temp dir is harmless.
+            }
+        }
+    }
+
+    private static string BuildProject(HostCompileOptions options, string assemblyName, string viewFileName)
+    {
+        string closureDir = options.ClosureDirectory.Replace('\\', '/').TrimEnd('/');
+        string excludes = string.Join(';', options.ExcludePatterns.Select(p => $"{closureDir}/{p}"));
+
+        return $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>{options.TargetFramework}</TargetFramework>
+                <AssemblyName>{assemblyName}</AssemblyName>
+                <Nullable>disable</Nullable>
+                <ImplicitUsings>disable</ImplicitUsings>
+                <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+                <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+                <AvaloniaXamlIlDebuggerLaunch>false</AvaloniaXamlIlDebuggerLaunch>
+                <Configuration>Debug</Configuration>
+                <NoWarn>$(NoWarn);CS8021;NU1701;MSB3277</NoWarn>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Avalonia" Version="{options.AvaloniaVersion}" />
+              </ItemGroup>
+              <ItemGroup>
+                <Compile Include="IgnoresAccessChecks.cs" />
+                <AvaloniaXaml Include="Views/{viewFileName}" />
+              </ItemGroup>
+              <ItemGroup>
+                <Reference Include="{closureDir}/*.dll" Exclude="{excludes}" />
+              </ItemGroup>
+            </Project>
+            """;
+    }
+
+    private static string BuildIgnoresAccessChecks(IReadOnlyList<string> assemblyNames)
+    {
+        StringBuilder builder = new();
+
+        // Assembly-level attributes must precede any type declaration (CS1730), so emit them first; the
+        // attribute type defined below is still resolved across the file.
+        foreach (string assemblyName in assemblyNames)
+            builder.AppendLine($"[assembly: System.Runtime.CompilerServices.IgnoresAccessChecksTo(\"{assemblyName}\")]");
+
+        builder.AppendLine("namespace System.Runtime.CompilerServices");
+        builder.AppendLine("{");
+        builder.AppendLine("    [System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = true)]");
+        builder.AppendLine("    internal sealed class IgnoresAccessChecksToAttribute : System.Attribute");
+        builder.AppendLine("    {");
+        builder.AppendLine("        public IgnoresAccessChecksToAttribute(string assemblyName) { AssemblyName = assemblyName; }");
+        builder.AppendLine("        public string AssemblyName { get; }");
+        builder.AppendLine("    }");
+        builder.AppendLine("}");
+        return builder.ToString();
+    }
+
+    private static void RunDotnetBuild(string projectPath, string workingDirectory)
+    {
+        ProcessStartInfo startInfo = new()
+        {
+            FileName = "dotnet",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("build");
+        startInfo.ArgumentList.Add(projectPath);
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add("Debug");
+        startInfo.ArgumentList.Add("-nologo");
+        startInfo.ArgumentList.Add("-v");
+        startInfo.ArgumentList.Add("quiet");
+
+        using Process process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start 'dotnet build'. Is the .NET SDK on PATH?");
+
+        string standardOutput = process.StandardOutput.ReadToEnd();
+        string standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"'dotnet build' failed (exit {process.ExitCode}):\n{standardOutput}\n{standardError}");
+    }
+}

--- a/src/HotAvalonia.HostCompiler/HotAvalonia.HostCompiler.csproj
+++ b/src/HotAvalonia.HostCompiler/HotAvalonia.HostCompiler.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>HotAvalonia</RootNamespace>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Single source of truth for the host/device naming contract (prefix + sidecar suffix). -->
+    <Compile Include="../HotAvalonia.Core/Xaml/HostCompiledXamlNaming.cs" Link="HostCompiledXamlNaming.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/HotAvalonia.HostCompiler/Program.cs
+++ b/src/HotAvalonia.HostCompiler/Program.cs
@@ -1,0 +1,215 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace HotAvalonia.HostCompiler;
+
+/// <summary>
+/// Provides the entry point for <c>HotAvalonia.HostCompiler</c>, the host-side XAML compiler that produces
+/// populate DLLs for AOT/iOS host-compiled hot reload.
+/// </summary>
+public static class Program
+{
+    private enum Verb
+    {
+        Compile,
+        Watch,
+    }
+
+    private sealed record ParsedArguments(
+        Verb Verb,
+        string Path,
+        string? AppProject,
+        string? Closure,
+        string? AvaloniaVersion,
+        string? TargetFramework,
+        string? Output,
+        IReadOnlyList<string> Excludes);
+
+    /// <summary>
+    /// The main entry point for the application.
+    /// </summary>
+    /// <param name="args">The command-line arguments.</param>
+    /// <returns><c>0</c> if the application ran successfully; otherwise, <c>1</c>.</returns>
+    internal static int Main(string[] args)
+    {
+        if (!TryParse(args, out ParsedArguments? parsed))
+        {
+            Console.Error.WriteLine(Help);
+            return 1;
+        }
+
+        try
+        {
+            CompileContext context = ResolveContext(parsed);
+            return parsed.Verb == Verb.Watch ? RunWatch(parsed.Path, context) : RunCompile(parsed, context);
+        }
+        catch (InvalidOperationException e)
+        {
+            Console.Error.WriteLine(e.Message);
+            return 1;
+        }
+    }
+
+    private static int RunCompile(ParsedArguments parsed, CompileContext context)
+    {
+        string output = HostXamlCompiler.Compile(new HostCompileOptions
+        {
+            ViewPath = parsed.Path,
+            ClosureDirectory = context.ClosureDirectory,
+            AvaloniaVersion = context.AvaloniaVersion,
+            TargetFramework = context.TargetFramework,
+            ExcludePatterns = context.ExcludePatterns,
+            OutputPath = parsed.Output,
+        });
+        Console.WriteLine(output);
+        return 0;
+    }
+
+    private static int RunWatch(string viewsDirectory, CompileContext context)
+    {
+        if (!Directory.Exists(viewsDirectory))
+            throw new InvalidOperationException($"Watch directory not found: {viewsDirectory}");
+
+        using CancellationTokenSource cancellation = new();
+        using PosixSignalRegistration sigint = PosixSignalRegistration.Create(PosixSignal.SIGINT, _ => cancellation.Cancel());
+        using PosixSignalRegistration? sigterm = OperatingSystem.IsWindows()
+            ? null
+            : PosixSignalRegistration.Create(PosixSignal.SIGTERM, _ => cancellation.Cancel());
+
+        Watcher.Run(viewsDirectory, context, cancellation.Token);
+        return 0;
+    }
+
+    private static CompileContext ResolveContext(ParsedArguments parsed)
+    {
+        string? closure = parsed.Closure;
+        string? avaloniaVersion = parsed.AvaloniaVersion;
+        string? targetFramework = parsed.TargetFramework;
+
+        if ((closure is null || avaloniaVersion is null || targetFramework is null) && parsed.AppProject is not null)
+        {
+            DiscoveryResult discovered = ProjectDiscovery.Discover(parsed.AppProject);
+            closure ??= discovered.ClosureDirectory;
+            avaloniaVersion ??= discovered.AvaloniaVersion;
+            targetFramework ??= discovered.TargetFramework;
+        }
+
+        if (closure is null || avaloniaVersion is null)
+            throw new InvalidOperationException("Provide --app-project for auto-discovery, or both --closure and --avalonia-version.");
+
+        return new CompileContext(
+            Path.GetFullPath(closure),
+            avaloniaVersion,
+            targetFramework ?? "net10.0",
+            parsed.Excludes.Count > 0 ? parsed.Excludes : HostXamlCompiler.DefaultExcludePatterns);
+    }
+
+    private static bool TryParse(string[] args, [NotNullWhen(true)] out ParsedArguments? parsed)
+    {
+        parsed = null;
+        if (args.Length == 0)
+            return false;
+
+        Verb verb = args[0] switch
+        {
+            "compile" => Verb.Compile,
+            "watch" => Verb.Watch,
+            _ => (Verb)(-1),
+        };
+        if ((int)verb < 0)
+            return false;
+
+        string? path = null;
+        string? appProject = null;
+        string? closure = null;
+        string? avaloniaVersion = null;
+        string? targetFramework = null;
+        string? output = null;
+        List<string> excludes = [];
+
+        for (int i = 1; i < args.Length; i++)
+        {
+            string arg = args[i];
+            switch (arg)
+            {
+                case "--app-project":
+                    if (!TryNext(args, ref i, out appProject))
+                        return false;
+                    break;
+                case "--closure":
+                    if (!TryNext(args, ref i, out closure))
+                        return false;
+                    break;
+                case "--avalonia-version":
+                    if (!TryNext(args, ref i, out avaloniaVersion))
+                        return false;
+                    break;
+                case "--tfm":
+                    if (!TryNext(args, ref i, out targetFramework))
+                        return false;
+                    break;
+                case "--output":
+                    if (!TryNext(args, ref i, out output))
+                        return false;
+                    break;
+                case "--exclude":
+                    if (!TryNext(args, ref i, out string? exclude))
+                        return false;
+                    excludes.Add(exclude);
+                    break;
+                default:
+                    if (arg.StartsWith('-') || path is not null)
+                        return false;
+                    path = arg;
+                    break;
+            }
+        }
+
+        if (path is null)
+            return false;
+
+        parsed = new ParsedArguments(
+            verb,
+            Path.GetFullPath(path),
+            appProject,
+            closure,
+            avaloniaVersion,
+            targetFramework,
+            output is null ? null : Path.GetFullPath(output),
+            excludes);
+        return true;
+    }
+
+    private static bool TryNext(string[] args, ref int index, out string value)
+    {
+        if (index + 1 >= args.Length)
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        value = args[++index];
+        return true;
+    }
+
+    private static string Name => Assembly.GetExecutingAssembly().GetName().Name ?? "HotAvalonia.HostCompiler";
+
+    private static string Help => $"""
+        {Name} - compiles changed Avalonia views into host-compiled populate DLLs (AOT/iOS hot reload).
+
+        Usage:
+          {Name} compile <view.axaml> (--app-project <csproj> | --closure <dir> --avalonia-version <ver>) [options]
+          {Name} watch <views-dir>    (--app-project <csproj> | --closure <dir> --avalonia-version <ver>) [options]
+
+        Inputs (auto-discovered from --app-project, or given explicitly):
+          --app-project <csproj>  App project (or its dir); infers --closure, --avalonia-version and --tfm.
+          --closure <dir>         The app's pre-link build-output directory (the device's reference closure).
+          --avalonia-version <v>  The exact Avalonia package version the app uses.
+
+        Options:
+          --tfm <tfm>             Target framework of the compile project (default: net10.0).
+          --output <path>         Output DLL path for 'compile' (default: <view>.axaml{Xaml.HostCompiledXamlNaming.SidecarSuffix}).
+          --exclude <glob>        File-name glob excluded from the closure (repeatable; overrides defaults).
+        """;
+}

--- a/src/HotAvalonia.HostCompiler/ProjectDiscovery.cs
+++ b/src/HotAvalonia.HostCompiler/ProjectDiscovery.cs
@@ -1,0 +1,116 @@
+using System.Text.Json;
+
+namespace HotAvalonia.HostCompiler;
+
+/// <summary>The values auto-discovered from a target app's restore/build output.</summary>
+internal readonly record struct DiscoveryResult(string ClosureDirectory, string AvaloniaVersion, string TargetFramework);
+
+/// <summary>
+/// Auto-discovers the inputs the compiler needs (the pre-link reference closure, the exact Avalonia
+/// version, and the compile target framework) from a target app's <c>obj/project.assets.json</c> and
+/// <c>bin</c> output, so a consumer only has to point the tool at their app project.
+/// </summary>
+internal static class ProjectDiscovery
+{
+    private static readonly string[] s_rids = ["ios-arm64", "iossimulator-arm64", "iossimulator-x64"];
+
+    /// <summary>
+    /// Discovers the closure/version/TFM from the given app <c>.csproj</c> (or a directory containing one).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The app hasn't been restored/built, or the inputs can't be inferred.</exception>
+    public static DiscoveryResult Discover(string appProjectOrDirectory)
+    {
+        string projectDir = ResolveProjectDirectory(appProjectOrDirectory);
+        string assetsPath = Path.Combine(projectDir, "obj", "project.assets.json");
+        if (!File.Exists(assetsPath))
+            throw new InvalidOperationException($"No restore output at {assetsPath}. Build the app (Debug) first.");
+
+        using JsonDocument document = JsonDocument.Parse(File.ReadAllText(assetsPath));
+        JsonElement root = document.RootElement;
+
+        string iosTargetFramework = ResolveIosTargetFramework(root);
+        string compileTargetFramework = iosTargetFramework.Split('-', 2)[0]; // net10.0-ios26.5 -> net10.0
+        string avaloniaVersion = ResolveAvaloniaVersion(root);
+        string closure = ResolveClosure(projectDir, iosTargetFramework);
+
+        return new DiscoveryResult(closure, avaloniaVersion, compileTargetFramework);
+    }
+
+    private static string ResolveProjectDirectory(string appProjectOrDirectory)
+    {
+        if (File.Exists(appProjectOrDirectory))
+            return Path.GetDirectoryName(Path.GetFullPath(appProjectOrDirectory))!;
+
+        if (Directory.Exists(appProjectOrDirectory))
+        {
+            string[] projects = Directory.GetFiles(appProjectOrDirectory, "*.csproj");
+            if (projects.Length == 1)
+                return Path.GetFullPath(appProjectOrDirectory);
+
+            throw new InvalidOperationException($"Expected exactly one .csproj in {appProjectOrDirectory}, found {projects.Length}.");
+        }
+
+        throw new InvalidOperationException($"App project or directory not found: {appProjectOrDirectory}");
+    }
+
+    private static string ResolveIosTargetFramework(JsonElement root)
+    {
+        if (root.TryGetProperty("project", out JsonElement project)
+            && project.TryGetProperty("frameworks", out JsonElement frameworks))
+        {
+            foreach (JsonProperty framework in frameworks.EnumerateObject())
+            {
+                if (framework.Name.Contains("-ios", StringComparison.Ordinal))
+                    return framework.Name;
+            }
+        }
+
+        throw new InvalidOperationException("Could not find an iOS target framework in project.assets.json.");
+    }
+
+    private static string ResolveAvaloniaVersion(JsonElement root)
+    {
+        if (root.TryGetProperty("libraries", out JsonElement libraries))
+        {
+            foreach (JsonProperty library in libraries.EnumerateObject())
+            {
+                if (library.Name.StartsWith("Avalonia/", StringComparison.Ordinal))
+                    return library.Name["Avalonia/".Length..];
+            }
+        }
+
+        throw new InvalidOperationException("Could not find the Avalonia package version in project.assets.json.");
+    }
+
+    private static string ResolveClosure(string projectDirectory, string iosTargetFramework)
+    {
+        string binRoot = Path.Combine(projectDirectory, "bin");
+        List<DirectoryInfo> candidates = [];
+
+        if (Directory.Exists(binRoot))
+        {
+            foreach (string tfmDirectory in Directory.EnumerateDirectories(binRoot, iosTargetFramework, SearchOption.AllDirectories))
+            {
+                foreach (string rid in s_rids)
+                {
+                    string candidate = Path.Combine(tfmDirectory, rid);
+
+                    // The rid directory itself is the untrimmed pre-link closure; System.Runtime.dll (rather
+                    // than only the linker-merged System.Private.CoreLib) confirms it isn't a trimmed .app build.
+                    if (Directory.Exists(candidate) && File.Exists(Path.Combine(candidate, "System.Runtime.dll")))
+                        candidates.Add(new DirectoryInfo(candidate));
+                }
+            }
+        }
+
+        if (candidates.Count == 0)
+            throw new InvalidOperationException($"No pre-link build output (bin/**/{iosTargetFramework}/<rid>/ with System.Runtime.dll) found. Build the iOS app (Debug) first.");
+
+        string debugSegment = $"{Path.DirectorySeparatorChar}Debug{Path.DirectorySeparatorChar}";
+        return candidates
+            .OrderByDescending(directory => directory.FullName.Contains(debugSegment, StringComparison.OrdinalIgnoreCase))
+            .ThenByDescending(directory => directory.LastWriteTimeUtc)
+            .First()
+            .FullName;
+    }
+}

--- a/src/HotAvalonia.HostCompiler/README.md
+++ b/src/HotAvalonia.HostCompiler/README.md
@@ -1,0 +1,51 @@
+# HotAvalonia.HostCompiler
+
+[![GitHub Build Status](https://img.shields.io/github/actions/workflow/status/Kira-NT/HotAvalonia/build.yml?logo=github)](https://github.com/Kira-NT/HotAvalonia/actions/workflows/build.yml)
+[![Version](https://img.shields.io/github/v/release/Kira-NT/HotAvalonia?sort=date&label=version)](https://github.com/Kira-NT/HotAvalonia/releases/latest)
+[![License](https://img.shields.io/github/license/Kira-NT/HotAvalonia?cacheSeconds=36000)](https://github.com/Kira-NT/HotAvalonia/blob/HEAD/LICENSE.md)
+
+`HotAvalonia.HostCompiler` compiles changed Avalonia XAML views on the **host** into standalone "populate" assemblies that a device loads and applies. It enables hot reload on targets where XAML can't be recompiled at runtime (no `Reflection.Emit`) — most notably **iOS**.
+
+It pairs with HotAvalonia's `UseHostCompiledXaml` mode: the host watches your `.axaml` files, compiles each change into a `<view>.axaml.hotreload.dll` sidecar next to the source, and HotAvalonia serves it to the device, which loads it and drives the view's `!XamlIlPopulateOverride` — no runtime codegen on the device.
+
+----
+
+## Usage
+
+```
+Usage:
+  HotAvalonia.HostCompiler compile <view.axaml> (--app-project <csproj> | --closure <dir> --avalonia-version <ver>) [options]
+  HotAvalonia.HostCompiler watch <views-dir>    (--app-project <csproj> | --closure <dir> --avalonia-version <ver>) [options]
+
+Inputs (auto-discovered from --app-project, or given explicitly):
+  --app-project <csproj>  App project (or its directory); infers --closure, --avalonia-version and --tfm.
+  --closure <dir>         The app's pre-link build-output directory (the device's reference closure).
+  --avalonia-version <v>  The exact Avalonia package version the app uses.
+
+Options:
+  --tfm <tfm>             Target framework of the compile project (default: net10.0).
+  --output <path>         Output DLL path for 'compile' (default: <view>.axaml.hotreload.dll).
+  --exclude <glob>        File-name glob excluded from the reference closure (repeatable; overrides defaults).
+```
+
+In the common case, `--app-project` is all you need: the tool reads the app's restore/build output (`obj/project.assets.json` + `bin`) to discover the reference closure, the exact Avalonia version, and the target framework. The app must be built once first so that output exists.
+
+----
+
+## How it works
+
+For a changed view, the tool:
+
+1. strips `x:Class` and qualifies each `clr-namespace` with its defining assembly (resolved from the closure via `System.Reflection.Metadata`), so types bind the device's exact identities;
+2. compiles the view with Avalonia's exact build-time XAML compiler, referencing the app's **pre-link** reference closure;
+3. emits a `<view>.axaml.hotreload.dll` sidecar (written atomically).
+
+The device side (`HotAvalonia.Core`, with `UseHostCompiledXaml`) loads that assembly, reflects out its `Build:`/`Populate:` methods, and applies them through Avalonia's `!XamlIlPopulateOverride` hook — the same emit-free path used for compiled-XAML reload.
+
+It's a dev-time host helper; nothing ships in Release builds.
+
+----
+
+## License
+
+Licensed under the terms of the [MIT License](https://github.com/Kira-NT/HotAvalonia/blob/HEAD/LICENSE.md).

--- a/src/HotAvalonia.HostCompiler/Watcher.cs
+++ b/src/HotAvalonia.HostCompiler/Watcher.cs
@@ -1,0 +1,75 @@
+using System.Collections.Concurrent;
+
+namespace HotAvalonia.HostCompiler;
+
+/// <summary>
+/// Watches a directory for <c>.axaml</c> changes and recompiles each changed view (the host-side analog of
+/// the device watcher). Debounced and serialized so rapid saves of the same view don't trigger overlapping
+/// compiles.
+/// </summary>
+internal static class Watcher
+{
+    private const int DebounceMilliseconds = 400;
+    private const int PollMilliseconds = 150;
+
+    /// <summary>
+    /// Runs the watch loop until <paramref name="cancellationToken"/> is signaled.
+    /// </summary>
+    public static void Run(string viewsDirectory, CompileContext context, CancellationToken cancellationToken)
+    {
+        ConcurrentDictionary<string, long> pending = new(StringComparer.OrdinalIgnoreCase);
+
+        using FileSystemWatcher watcher = new(viewsDirectory)
+        {
+            Filter = "*.axaml",
+            IncludeSubdirectories = true,
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size,
+        };
+
+        void Queue(string path) => pending[path] = Environment.TickCount64;
+        watcher.Changed += (_, e) => Queue(e.FullPath);
+        watcher.Created += (_, e) => Queue(e.FullPath);
+        watcher.Renamed += (_, e) => Queue(e.FullPath);
+        watcher.EnableRaisingEvents = true;
+
+        Console.WriteLine($"Watching {viewsDirectory} for *.axaml changes (Ctrl-C to stop)...");
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            cancellationToken.WaitHandle.WaitOne(PollMilliseconds);
+
+            long now = Environment.TickCount64;
+            foreach (KeyValuePair<string, long> entry in pending)
+            {
+                if (now - entry.Value < DebounceMilliseconds)
+                    continue;
+
+                if (pending.TryRemove(entry.Key, out _))
+                    CompileOne(entry.Key, context);
+            }
+        }
+    }
+
+    private static void CompileOne(string viewPath, CompileContext context)
+    {
+        if (!File.Exists(viewPath))
+            return;
+
+        try
+        {
+            string output = HostXamlCompiler.Compile(new HostCompileOptions
+            {
+                ViewPath = viewPath,
+                ClosureDirectory = context.ClosureDirectory,
+                AvaloniaVersion = context.AvaloniaVersion,
+                TargetFramework = context.TargetFramework,
+                ExcludePatterns = context.ExcludePatterns,
+            });
+            Console.WriteLine($"compiled {Path.GetFileName(viewPath)} -> {output}");
+        }
+        catch (InvalidOperationException e)
+        {
+            Console.Error.WriteLine($"failed {Path.GetFileName(viewPath)}: {e.Message}");
+        }
+    }
+}

--- a/src/HotAvalonia/HotAvalonia.csproj
+++ b/src/HotAvalonia/HotAvalonia.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <HarfsTargetFramework>net7.0</HarfsTargetFramework>
+    <HostCompilerTargetFramework>net10.0</HostCompilerTargetFramework>
     <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
     <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
     <DisableFody>true</DisableFody>
@@ -24,11 +25,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <ProjectReference Include="../HotAvalonia.Remote/HotAvalonia.Remote.csproj" SetTargetFramework="TargetFramework=$(HarfsTargetFramework)" SkipGetTargetFrameworkProperties="True" ReferenceOutputAssembly="False" />
+    <ProjectReference Include="../HotAvalonia.HostCompiler/HotAvalonia.HostCompiler.csproj" SetTargetFramework="TargetFramework=$(HostCompilerTargetFramework)" SkipGetTargetFrameworkProperties="True" ReferenceOutputAssembly="False" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="../HotAvalonia.Remote/bin/$(Configuration)/$(HarfsTargetFramework)/HotAvalonia.Remote.dll" PackagePath="tools/" Pack="true" Visible="false" />
     <None Include="../HotAvalonia.Remote/bin/$(Configuration)/$(HarfsTargetFramework)/HotAvalonia.Remote.runtimeconfig.json" PackagePath="tools/" Pack="true" Visible="false" />
+    <None Include="../HotAvalonia.HostCompiler/bin/$(Configuration)/$(HostCompilerTargetFramework)/HotAvalonia.HostCompiler.dll" PackagePath="tools/" Pack="true" Visible="false" />
+    <None Include="../HotAvalonia.HostCompiler/bin/$(Configuration)/$(HostCompilerTargetFramework)/HotAvalonia.HostCompiler.runtimeconfig.json" PackagePath="tools/" Pack="true" Visible="false" />
   </ItemGroup>
 
   <Target Name="ExpandProps">

--- a/src/HotAvalonia/HotAvalonia.targets
+++ b/src/HotAvalonia/HotAvalonia.targets
@@ -122,6 +122,14 @@
     <DefineConstants Condition="!$(HotAvaloniaIncludeExtensions)">$(DefineConstants)$(_HotAvaloniaDefineConstantsSeparator)HOTAVALONIA_EXCLUDE_EXTENSIONS</DefineConstants>
   </PropertyGroup>
 
+  <!-- Bake the project's source root into the assembly so the runtime locator can find the .axaml
+       sources on iOS, where the Full linker strips the debug info it would otherwise read.
+       Use Contains('-ios') (not _HotAvaloniaIsIOS, which is EndsWith) so versioned TFMs like
+       net10.0-ios26.5 are matched. -->
+  <ItemGroup Condition="$(HotAvalonia) And $(TargetFramework.Contains('-ios'))">
+    <AssemblyMetadata Include="HotAvalonia.SourceRoot" Value="$(MSBuildProjectDirectory)" />
+  </ItemGroup>
+
   <PropertyGroup Label="HotAvalonia: iOS Properties" Condition="$(HotAvalonia) And $(_HotAvaloniaIsIOS)">
     <!-- Force-enable Mono Interpreter on iOS to accommodate the platform's fundamental design flaws. -->
     <MtouchInterpreter>all</MtouchInterpreter>


### PR DESCRIPTION
## Why
iOS forbids runtime `Reflection.Emit`, so HotAvalonia's on-device XAML recompilation can't run there — iOS has been unsupported. This adds a **host-compiled** mode: the host compiles each changed view into a populate DLL that the device loads and applies via the existing `!XamlIlPopulateOverride` path. No runtime codegen on the device.

## What's in it
- **`AvaloniaHotReloadConfig.UseHostCompiledXaml`** (defaults to `true` on iOS) — load a host-compiled populate assembly instead of recompiling XAML on-device.
- **Three iOS blockers fixed in `HotAvalonia.Core`:**
  - BCL `FileSystemWatcher` event types are throw-stubs on iOS → replaced with internal `FileChange*` types across the watcher chain (desktop still translates the BCL events).
  - The iOS Full linker trims `CompiledAvaloniaXaml.!XamlLoader` → document discovery falls back to a type scan instead of bailing.
  - The linker strips the debug info the project locator reads → the views' source root is baked in as `AssemblyMetadata` and read at runtime (no manual hint).
- **New `HotAvalonia.HostCompiler` tool** (cross-platform; bundled in the package `tools/`) — compiles a view to a `<view>.axaml.hotreload.dll` sidecar, plus a `--watch` mode; auto-discovers the reference closure + Avalonia version from the app project.

Desktop and Android are unchanged — the new paths are iOS-gated / opt-in.

## How to use (iOS)
1. Reference `HotAvalonia` in your iOS app + Avalonia views projects (Debug). A stock app needs **no code** — it auto-enables, `UseHostCompiledXaml` defaults on for iOS, and the source root is baked in (no `AddHint`).
2. On the Mac, start the host server + compiler — one command:
   ```sh
   samples/host-compiled/hotreload.sh --app-project <App.iOS.csproj>
   ```
   *(or run `HotAvalonia.Remote` + `HotAvalonia.HostCompiler watch` from `tools/` yourself).*
3. Deploy a Debug build to the device once. Then **edit a `.axaml` and save** — on save, the changed view is recompiled on the host and applied to the running view on the device, with **no rebuild or redeploy**.

## Notes
- Tested end-to-end on a physical iOS device.
- iOS-only for the host-compiled path; desktop/Android keep on-device compilation.
- Dev-time only — nothing ships in Release.
